### PR TITLE
Add market relevance filter and prepare soak test (#37)

### DIFF
--- a/e2e/soak_test.py
+++ b/e2e/soak_test.py
@@ -72,6 +72,8 @@ async def run_soak(
     # Clean previous soak data only if explicitly requested
     engine = PaperTradingEngine(db_path=SOAK_DB_PATH, initial_cash=1000.0)
 
+    from pipeline.trigger import DEFAULT_RELEVANCE_KEYWORDS
+
     config = PipelineConfig(
         simulation_id=simulation_id,
         graph_id=graph_id,
@@ -79,6 +81,7 @@ async def run_soak(
         max_markets=max_markets,
         signal_log_path=SOAK_SIGNAL_LOG,
         calibration_gate=gate_enabled,
+        relevance_keywords=DEFAULT_RELEVANCE_KEYWORDS,
     )
 
     trigger = PipelineTrigger(config=config, paper_engine=engine)
@@ -238,7 +241,7 @@ async def main():
     p_start = sub.add_parser("start", help="Start the soak test")
     p_start.add_argument("--hours", type=float, default=72)
     p_start.add_argument("--interval", type=int, default=1800)
-    p_start.add_argument("--max-markets", type=int, default=10)
+    p_start.add_argument("--max-markets", type=int, default=20)
     p_start.add_argument("--simulation-id", default="")
     p_start.add_argument("--graph-id", default="")
     p_start.add_argument("--no-gate", action="store_true", help="Disable calibration gate")

--- a/pipeline/trigger.py
+++ b/pipeline/trigger.py
@@ -40,6 +40,26 @@ GAMMA_API_BASE = "https://gamma-api.polymarket.com"
 
 DEFAULT_SIGNAL_LOG = Path(__file__).resolve().parent.parent / "data" / "signal_log.jsonl"
 
+# Default keywords matching agent expertise domains (crypto/finance/geopolitics/tech).
+# Used to skip markets agents have no knowledge about (sports, weather, etc.).
+DEFAULT_RELEVANCE_KEYWORDS = [
+    # Crypto
+    "bitcoin", "btc", "ethereum", "eth", "crypto", "defi", "blockchain",
+    "nft", "stablecoin", "solana", "xrp", "token", "mining", "halving",
+    # Finance
+    "fed", "federal reserve", "interest rate", "inflation", "gdp", "recession",
+    "stock", "s&p", "nasdaq", "etf", "bond", "treasury", "bank",
+    # Geopolitics
+    "president", "election", "trump", "biden", "congress", "senate",
+    "war", "strike", "sanctions", "tariff", "nato", "china", "russia",
+    "iran", "israel", "ukraine", "military", "nuclear",
+    # Tech
+    "deepseek", "openai", "google", "apple", "tesla", "spacex",
+    "semiconductor", "chip",
+    # Markets
+    "polymarket", "prediction market", "price",
+]
+
 
 # ── Config ────────────────────────────────────────────────────────────────────
 
@@ -53,11 +73,12 @@ class PipelineConfig:
     interval_seconds: int = 1800          # 30 minutes
     max_markets: int = 10                 # top N markets by volume
     market_category: str = ""             # filter by category (empty = all)
-    interview_timeout: int = 120          # seconds
+    interview_timeout: int = 300          # seconds (22 agents need ~5 min)
     signal_log_path: Path = DEFAULT_SIGNAL_LOG
     exit_config: Any = None               # ExitConfig for exit monitoring (None = disabled)
     calibration_gate: bool = False         # enable oracle-based calibration gate
     gate_max_brier: float = 0.25          # max Brier score to allow trading
+    relevance_keywords: list[str] = field(default_factory=list)  # empty = no filter
 
     def __post_init__(self):
         self.mirofish_url = self.mirofish_url or os.getenv("MIROFISH_BACKEND", "http://localhost:5001")
@@ -295,6 +316,22 @@ class PipelineTrigger:
                 graph_id=self.config.graph_id,
             )
 
+    def _is_market_relevant(self, market: ActiveMarket) -> bool:
+        """Check if a market question matches agent expertise domains.
+
+        Returns True if no keywords configured (permissive) or if any
+        keyword appears as a whole word in the question text.
+        """
+        keywords = self.config.relevance_keywords
+        if not keywords:
+            return True
+        q = market.question.lower()
+        for kw in keywords:
+            # Use word boundary regex to avoid "ai" matching inside "Taishan"
+            if re.search(r'\b' + re.escape(kw) + r'\b', q):
+                return True
+        return False
+
     def _get_edge_calculator(self):
         from trading.edge_calculator import EdgeCalculator, EdgeConfig
         config = self._edge_config or EdgeConfig()
@@ -350,6 +387,33 @@ class PipelineTrigger:
 
             if not markets:
                 logger.warning("No active markets found")
+                return signals_log
+
+            # Filter to markets matching agent expertise
+            if self.config.relevance_keywords:
+                before = len(markets)
+                relevant = [m for m in markets if self._is_market_relevant(m)]
+                skipped = before - len(relevant)
+                if skipped:
+                    logger.info(
+                        "Relevance filter: %d/%d markets skipped (not matching agent expertise)",
+                        skipped, before,
+                    )
+                    for m in markets:
+                        if not self._is_market_relevant(m):
+                            signals_log.append({
+                                "cycle_time": cycle_time,
+                                "market_id": m.id,
+                                "question": m.question,
+                                "market_price": m.current_price,
+                                "action": "SKIP",
+                                "reason": "market not relevant to agent expertise",
+                                "executed": False,
+                            })
+                markets = relevant
+
+            if not markets:
+                logger.warning("No relevant markets after filtering")
                 return signals_log
 
             calc = self._get_edge_calculator()

--- a/tests/test_pipeline_trigger.py
+++ b/tests/test_pipeline_trigger.py
@@ -90,6 +90,58 @@ class TestAggregateProbabilities:
         assert abs(result - 0.65) < 1e-10
 
 
+# ── Relevance filter ──────────────────────────────────────────────────────────
+
+
+class TestRelevanceFilter:
+    def _make_market(self, question):
+        return ActiveMarket(
+            id="0x1", question=question, token_ids=["t1"],
+            current_price=0.5, volume=100, category="",
+        )
+
+    def test_crypto_market_relevant(self):
+        config = PipelineConfig(relevance_keywords=["bitcoin", "ethereum"])
+        trigger = PipelineTrigger(config=config)
+        assert trigger._is_market_relevant(self._make_market("Will Bitcoin hit $100k?"))
+
+    def test_sports_market_not_relevant(self):
+        config = PipelineConfig(relevance_keywords=["bitcoin", "ethereum"])
+        trigger = PipelineTrigger(config=config)
+        assert not trigger._is_market_relevant(self._make_market("Will the Lakers win tonight?"))
+
+    def test_case_insensitive(self):
+        config = PipelineConfig(relevance_keywords=["bitcoin"])
+        trigger = PipelineTrigger(config=config)
+        assert trigger._is_market_relevant(self._make_market("BITCOIN price prediction"))
+
+    def test_empty_keywords_allows_all(self):
+        config = PipelineConfig(relevance_keywords=[])
+        trigger = PipelineTrigger(config=config)
+        assert trigger._is_market_relevant(self._make_market("Anything at all"))
+
+    def test_geopolitics_relevant(self):
+        config = PipelineConfig(relevance_keywords=["war", "iran", "israel"])
+        trigger = PipelineTrigger(config=config)
+        assert trigger._is_market_relevant(self._make_market("Will Israel strike Iran?"))
+
+    def test_word_in_sentence(self):
+        config = PipelineConfig(relevance_keywords=["bitcoin"])
+        trigger = PipelineTrigger(config=config)
+        assert trigger._is_market_relevant(self._make_market("Price of bitcoin on April 5"))
+
+    def test_no_substring_false_positive(self):
+        """'ai' should not match inside 'Taishan'."""
+        config = PipelineConfig(relevance_keywords=["ai"])
+        trigger = PipelineTrigger(config=config)
+        assert not trigger._is_market_relevant(self._make_market("Shandong Taishan FC (-1.5)"))
+
+    def test_multi_word_keyword(self):
+        config = PipelineConfig(relevance_keywords=["interest rate"])
+        trigger = PipelineTrigger(config=config)
+        assert trigger._is_market_relevant(self._make_market("Will interest rate stay at 4%?"))
+
+
 # ── Active market ─────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- **Market relevance filter** in pipeline trigger — skips markets outside agent expertise using word-boundary keyword matching
- Default keywords cover crypto, finance, geopolitics, tech domains (matching the 11 MiroFish agent personas)
- Increased interview timeout from 120s to 300s (22 agents need ~5 min)
- Soak test defaults to fetching 20 markets (filters down to 3-5 relevant)

### Validated against live Polymarket:
- Sports markets (golf, basketball, football) correctly filtered out
- Geopolitics (Israel, Iran) and crypto markets pass through
- Agents give non-trivial estimates on relevant markets (0.41 for Israel, not 0.50)

Partial fix for #37

## Test plan
- [x] 34 tests pass (8 new relevance filter tests)
- [x] Word boundary matching prevents "ai" matching "Taishan"
- [x] Multi-word keywords ("interest rate") work correctly
- [x] Empty keywords = no filtering (backward compatible)