### PR TITLE
Add Fear & Greed Index and PredictIt connectors (#40 Phase 1)

### DIFF
--- a/ingestors/fear_greed.py
+++ b/ingestors/fear_greed.py
@@ -1,0 +1,192 @@
+"""
+Crypto Fear & Greed Index connector — polls the Alternative.me API for
+current sentiment values and computes short-term trend direction.
+
+Endpoint: https://api.alternative.me/fng/
+Free, no API key required, ~60 req/min.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+import aiohttp
+
+logger = logging.getLogger("prememora.ingestors.fear_greed")
+
+BASE_URL = "https://api.alternative.me/fng/"
+
+EventCallback = Callable[[Dict[str, Any]], Awaitable[None]]
+
+
+def _compute_trend(values: List[int]) -> str:
+    """Compute trend direction from a list of chronological FNG values.
+
+    The API returns newest-first, so callers must reverse before passing
+    here if needed.  Expects oldest-first order.
+
+    Returns 'rising', 'falling', or 'stable'.
+    """
+    if len(values) < 2:
+        return "stable"
+
+    # Compare recent half average to older half average.
+    mid = len(values) // 2
+    old_avg = sum(values[:mid]) / mid
+    new_avg = sum(values[mid:]) / (len(values) - mid)
+    diff = new_avg - old_avg
+
+    if diff > 3:
+        return "rising"
+    elif diff < -3:
+        return "falling"
+    return "stable"
+
+
+def _parse_fng_entry(entry: Dict[str, Any]) -> tuple[int, str, str]:
+    """Parse a single FNG API entry into (value, classification, timestamp_iso)."""
+    value = int(entry.get("value", 0))
+    classification = entry.get("value_classification", "Unknown")
+    ts_unix = int(entry.get("timestamp", 0))
+    ts_iso = datetime.fromtimestamp(ts_unix, tz=timezone.utc).isoformat() if ts_unix else datetime.now(timezone.utc).isoformat()
+    return value, classification, ts_iso
+
+
+@dataclass
+class FearGreedConnector:
+    """Polls the Crypto Fear & Greed Index and emits events via callback.
+
+    Parameters
+    ----------
+    callback : EventCallback | None
+        Async function called with each new FNG event dict.
+    poll_interval : float
+        Seconds between polls (default: 3600 = 1 hour).
+    """
+
+    callback: Optional[EventCallback] = None
+    poll_interval: float = 3600.0
+    _running: bool = field(default=False, init=False)
+    _last_value: Optional[int] = field(default=None, init=False)
+    _session: Optional[aiohttp.ClientSession] = field(default=None, init=False, repr=False)
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=30),
+                headers={"Accept": "application/json"},
+            )
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    async def _fetch_fng(self, limit: int = 1) -> List[Dict[str, Any]]:
+        """Fetch FNG data from the API. Returns raw entries list."""
+        session = await self._get_session()
+        try:
+            async with session.get(BASE_URL, params={"limit": limit}) as resp:
+                if resp.status != 200:
+                    logger.warning("FNG API returned %d", resp.status)
+                    return []
+                data = await resp.json(content_type=None)
+                return data.get("data", [])
+        except Exception as e:
+            logger.error("Failed to fetch FNG data: %s", e)
+            return []
+
+    async def poll_once(self) -> Optional[Dict[str, Any]]:
+        """Single fetch: get current value + 7-day history for trend.
+
+        Returns an event dict or None on failure.
+        """
+        # Fetch 7 days of history (includes current).
+        entries = await self._fetch_fng(limit=7)
+        if not entries:
+            return None
+
+        # Current value is the first entry (newest).
+        current_value, classification, timestamp = _parse_fng_entry(entries[0])
+
+        # Previous value (yesterday) if available.
+        previous_value: Optional[int] = None
+        if len(entries) > 1:
+            previous_value = int(entries[1].get("value", 0))
+
+        # Compute trend from history (reverse to oldest-first).
+        history_values = [int(e.get("value", 0)) for e in reversed(entries)]
+        trend = _compute_trend(history_values)
+
+        event: Dict[str, Any] = {
+            "source": "fear_greed",
+            "timestamp": timestamp,
+            "value": current_value,
+            "classification": classification,
+            "previous_value": previous_value,
+            "trend": trend,
+        }
+
+        self._last_value = current_value
+        return event
+
+    async def start(self) -> None:
+        """Start the polling loop. Runs until stop() is called."""
+        self._running = True
+        logger.info("Fear & Greed connector starting, interval=%ss", self.poll_interval)
+
+        while self._running:
+            try:
+                event = await self.poll_once()
+                if event and self.callback:
+                    await self.callback(event)
+                if event:
+                    logger.info(
+                        "FNG: %d (%s), trend=%s",
+                        event["value"],
+                        event["classification"],
+                        event["trend"],
+                    )
+            except Exception:
+                logger.exception("Error during FNG poll cycle")
+
+            await asyncio.sleep(self.poll_interval)
+
+    def stop(self) -> None:
+        """Signal the polling loop to stop after the current cycle."""
+        self._running = False
+
+
+# ── Standalone demo ──────────────────────────────────────────────────────────
+
+
+async def _main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    )
+
+    async def print_event(event: Dict[str, Any]) -> None:
+        print(
+            f"[{event['timestamp']}] Fear & Greed: {event['value']} "
+            f"({event['classification']}), prev={event['previous_value']}, "
+            f"trend={event['trend']}"
+        )
+
+    connector = FearGreedConnector(callback=print_event, poll_interval=60)
+    print("Polling Fear & Greed Index — Ctrl-C to stop\n")
+
+    try:
+        await connector.start()
+    except KeyboardInterrupt:
+        connector.stop()
+    finally:
+        await connector.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/ingestors/orchestrator.py
+++ b/ingestors/orchestrator.py
@@ -141,6 +141,33 @@ def _normalize_fred(event: dict[str, Any]) -> str:
     return text
 
 
+def _normalize_fear_greed(event: dict[str, Any]) -> str:
+    value = event.get("value", "?")
+    classification = event.get("classification", "Unknown")
+    previous = event.get("previous_value")
+    trend = event.get("trend", "stable")
+
+    text = f"Crypto Fear & Greed Index: {value} ({classification}), trend: {trend}"
+    if previous is not None:
+        text += f", previous: {previous}"
+    return text
+
+
+def _normalize_predictit(event: dict[str, Any]) -> str:
+    market_name = event.get("market_name", "Unknown market")
+    market_id = event.get("market_id", "?")
+    contracts = event.get("contracts", [])
+
+    parts = [f"PredictIt market [{market_id}]: {market_name}"]
+    for c in contracts[:5]:
+        name = c.get("name", "?")
+        price = c.get("price", "?")
+        parts.append(f"  {name}: ${price}")
+    if len(contracts) > 5:
+        parts.append(f"  ... and {len(contracts) - 5} more contracts")
+    return "\n".join(parts)
+
+
 _NORMALIZERS: dict[str, Any] = {
     "polymarket_ws": _normalize_polymarket,
     "crypto_news": _normalize_crypto_news,
@@ -148,6 +175,8 @@ _NORMALIZERS: dict[str, Any] = {
     "whale_alert": _normalize_whale,
     "reddit": _normalize_reddit,
     "fred": _normalize_fred,
+    "fear_greed": _normalize_fear_greed,
+    "predictit": _normalize_predictit,
 }
 
 
@@ -185,6 +214,10 @@ def _dedup_key(event: dict[str, Any]) -> str:
         raw = event.get("post_id") or event.get("url", "")
     elif source == "fred":
         raw = f"{event.get('series_id')}:{event.get('timestamp')}"
+    elif source == "fear_greed":
+        raw = f"{event.get('value')}:{event.get('timestamp')}"
+    elif source == "predictit":
+        raw = f"{event.get('market_id')}:{event.get('timestamp')}"
     else:
         raw = str(event)
 
@@ -241,6 +274,8 @@ class IngestionOrchestrator:
     enable_whale: bool = True
     enable_reddit: bool = True
     enable_fred: bool = True
+    enable_fear_greed: bool = True
+    enable_predictit: bool = True
 
     # Internals
     _dedup: _LRUDedup = field(default_factory=_LRUDedup, init=False)
@@ -338,6 +373,18 @@ class IngestionOrchestrator:
             c = FredMacroConnector(callback=self._handle_event_batch)
             connectors.append(("fred", c))
 
+        if self.enable_fear_greed:
+            from ingestors.fear_greed import FearGreedConnector
+
+            c = FearGreedConnector(callback=self._handle_event)
+            connectors.append(("fear_greed", c))
+
+        if self.enable_predictit:
+            from ingestors.predictit import PredictItConnector
+
+            c = PredictItConnector(callback=self._handle_event)
+            connectors.append(("predictit", c))
+
         return connectors
 
     # ── Lifecycle ─────────────────────────────────────────────────────
@@ -376,6 +423,8 @@ class IngestionOrchestrator:
         #   - WhaleTracker.start()           (async, blocks)
         #   - RedditSentimentConnector.start() (async, blocks)
         #   - FredMacroConnector.start()     (async, creates background task)
+        #   - FearGreedConnector.start()     (async, blocks)
+        #   - PredictItConnector.start()     (async, blocks)
         for name, connector in named_connectors:
             if hasattr(connector, "run") and name == "rss":
                 coro = connector.run()

--- a/ingestors/predictit.py
+++ b/ingestors/predictit.py
@@ -1,0 +1,187 @@
+"""
+PredictIt Political Market Prices connector — polls the PredictIt API for
+active prediction market data and emits events for markets with price changes.
+
+Endpoint: https://www.predictit.org/api/marketdata/all/
+Free, no API key required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+import aiohttp
+
+logger = logging.getLogger("prememora.ingestors.predictit")
+
+API_URL = "https://www.predictit.org/api/marketdata/all/"
+
+EventCallback = Callable[[Dict[str, Any]], Awaitable[None]]
+
+
+def _extract_contracts(market: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Extract contract data from a PredictIt market response."""
+    contracts = []
+    for c in market.get("contracts", []):
+        contracts.append({
+            "name": c.get("name", ""),
+            "price": c.get("lastTradePrice"),
+            "volume": c.get("totalSharesTraded", 0),
+        })
+    return contracts
+
+
+def _market_fingerprint(contracts: List[Dict[str, Any]]) -> str:
+    """Create a fingerprint of contract prices for change detection.
+
+    Returns a string like "name1:0.62|name2:0.38" sorted by contract name
+    so the fingerprint is stable across API call ordering changes.
+    """
+    parts = sorted(f"{c['name']}:{c['price']}" for c in contracts)
+    return "|".join(parts)
+
+
+def _build_market_event(market: Dict[str, Any], timestamp: str) -> Dict[str, Any]:
+    """Build an event dict from a PredictIt market."""
+    contracts = _extract_contracts(market)
+    return {
+        "source": "predictit",
+        "timestamp": timestamp,
+        "market_id": str(market.get("id", "")),
+        "market_name": market.get("name", ""),
+        "contracts": contracts,
+    }
+
+
+@dataclass
+class PredictItConnector:
+    """Polls PredictIt for active market data, emitting events on price change.
+
+    Parameters
+    ----------
+    callback : EventCallback | None
+        Async function called with each changed-market event dict.
+    poll_interval : float
+        Seconds between polls (default: 1800 = 30 minutes).
+    """
+
+    callback: Optional[EventCallback] = None
+    poll_interval: float = 1800.0
+    _running: bool = field(default=False, init=False)
+    _last_fingerprints: Dict[str, str] = field(default_factory=dict, init=False)
+    _session: Optional[aiohttp.ClientSession] = field(default=None, init=False, repr=False)
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=60),
+                headers={"Accept": "application/json"},
+            )
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    async def _fetch_markets(self) -> List[Dict[str, Any]]:
+        """Fetch all active markets from PredictIt."""
+        session = await self._get_session()
+        try:
+            async with session.get(API_URL) as resp:
+                if resp.status != 200:
+                    logger.warning("PredictIt API returned %d", resp.status)
+                    return []
+                data = await resp.json(content_type=None)
+                return data.get("markets", [])
+        except Exception as e:
+            logger.error("Failed to fetch PredictIt markets: %s", e)
+            return []
+
+    async def poll_once(self) -> List[Dict[str, Any]]:
+        """Single fetch: get all markets, return only those with price changes.
+
+        On first poll, all markets are considered 'changed' (initial snapshot).
+        """
+        raw_markets = await self._fetch_markets()
+        if not raw_markets:
+            return []
+
+        timestamp = datetime.now(timezone.utc).isoformat()
+        changed_events: List[Dict[str, Any]] = []
+
+        for market in raw_markets:
+            market_id = str(market.get("id", ""))
+            if not market_id:
+                continue
+
+            contracts = _extract_contracts(market)
+            fingerprint = _market_fingerprint(contracts)
+
+            old_fp = self._last_fingerprints.get(market_id)
+            if old_fp == fingerprint:
+                # No price change — skip.
+                continue
+
+            self._last_fingerprints[market_id] = fingerprint
+            event = _build_market_event(market, timestamp)
+            changed_events.append(event)
+
+        return changed_events
+
+    async def start(self) -> None:
+        """Start the polling loop. Runs until stop() is called."""
+        self._running = True
+        logger.info("PredictIt connector starting, interval=%ss", self.poll_interval)
+
+        while self._running:
+            try:
+                events = await self.poll_once()
+                if events:
+                    logger.info("PredictIt: %d markets changed", len(events))
+                    if self.callback:
+                        for event in events:
+                            await self.callback(event)
+            except Exception:
+                logger.exception("Error during PredictIt poll cycle")
+
+            await asyncio.sleep(self.poll_interval)
+
+    def stop(self) -> None:
+        """Signal the polling loop to stop after the current cycle."""
+        self._running = False
+
+
+# ── Standalone demo ──────────────────────────────────────────────────────────
+
+
+async def _main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    )
+
+    async def print_event(event: Dict[str, Any]) -> None:
+        contracts_str = ", ".join(
+            f"{c['name']}: ${c['price']}" for c in event["contracts"][:3]
+        )
+        suffix = "..." if len(event["contracts"]) > 3 else ""
+        print(f"  [{event['market_id']}] {event['market_name']}")
+        print(f"    {contracts_str}{suffix}")
+
+    connector = PredictItConnector(callback=print_event, poll_interval=60)
+    print("Polling PredictIt markets — Ctrl-C to stop\n")
+
+    try:
+        await connector.start()
+    except KeyboardInterrupt:
+        connector.stop()
+    finally:
+        await connector.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/tests/test_fear_greed.py
+++ b/tests/test_fear_greed.py
@@ -1,0 +1,235 @@
+"""Tests for the Fear & Greed Index connector — API parsing, trend calculation, polling."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from aiohttp import ClientSession
+
+from ingestors.fear_greed import (
+    FearGreedConnector,
+    _compute_trend,
+    _parse_fng_entry,
+)
+
+
+# ── Trend computation ────────────────────────────────────────────────────────
+
+
+class TestComputeTrend:
+    def test_rising(self):
+        # Oldest to newest: values climbing
+        assert _compute_trend([20, 25, 30, 40, 50, 60, 70]) == "rising"
+
+    def test_falling(self):
+        # Oldest to newest: values dropping
+        assert _compute_trend([70, 60, 50, 40, 30, 25, 20]) == "falling"
+
+    def test_stable(self):
+        # Flat values within threshold
+        assert _compute_trend([50, 50, 51, 50, 49, 50, 50]) == "stable"
+
+    def test_single_value(self):
+        assert _compute_trend([50]) == "stable"
+
+    def test_empty(self):
+        assert _compute_trend([]) == "stable"
+
+    def test_two_values_rising(self):
+        assert _compute_trend([30, 40]) == "rising"
+
+    def test_two_values_stable(self):
+        assert _compute_trend([50, 51]) == "stable"
+
+    def test_boundary_exactly_three(self):
+        # diff of exactly 3 should be stable (threshold is >3)
+        assert _compute_trend([47, 50]) == "stable"
+
+    def test_boundary_just_over_three(self):
+        # diff of 4 should be rising
+        assert _compute_trend([46, 50]) == "rising"
+
+
+# ── FNG entry parsing ────────────────────────────────────────────────────────
+
+
+class TestParseFngEntry:
+    def test_basic_entry(self):
+        entry = {
+            "value": "73",
+            "value_classification": "Greed",
+            "timestamp": "1711929600",
+        }
+        value, classification, ts = _parse_fng_entry(entry)
+        assert value == 73
+        assert classification == "Greed"
+        assert "2024" in ts  # timestamp 1711929600 is in 2024
+
+    def test_missing_fields(self):
+        value, classification, ts = _parse_fng_entry({})
+        assert value == 0
+        assert classification == "Unknown"
+        assert ts  # should fallback to now
+
+    def test_zero_timestamp_fallback(self):
+        entry = {"value": "50", "value_classification": "Neutral", "timestamp": "0"}
+        value, classification, ts = _parse_fng_entry(entry)
+        assert value == 50
+        assert ts  # should have a timestamp (fallback to now)
+
+
+# ── Connector poll_once ──────────────────────────────────────────────────────
+
+
+class TestFearGreedConnector:
+    def test_defaults(self):
+        connector = FearGreedConnector()
+        assert connector.poll_interval == 3600.0
+        assert connector.callback is None
+        assert connector._last_value is None
+
+    @pytest.mark.asyncio
+    async def test_poll_once_with_mock_api(self):
+        """Mock the API response and verify poll_once returns correct event."""
+        mock_response_data = {
+            "data": [
+                {"value": "73", "value_classification": "Greed", "timestamp": "1711929600"},
+                {"value": "65", "value_classification": "Greed", "timestamp": "1711843200"},
+                {"value": "60", "value_classification": "Greed", "timestamp": "1711756800"},
+                {"value": "55", "value_classification": "Greed", "timestamp": "1711670400"},
+                {"value": "45", "value_classification": "Fear", "timestamp": "1711584000"},
+                {"value": "40", "value_classification": "Fear", "timestamp": "1711497600"},
+                {"value": "35", "value_classification": "Fear", "timestamp": "1711411200"},
+            ]
+        }
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=mock_response_data)
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.closed = False
+
+        connector = FearGreedConnector()
+        connector._session = mock_session
+
+        event = await connector.poll_once()
+
+        assert event is not None
+        assert event["source"] == "fear_greed"
+        assert event["value"] == 73
+        assert event["classification"] == "Greed"
+        assert event["previous_value"] == 65
+        assert event["trend"] == "rising"  # 35,40,45,55,60,65,73 is rising
+        assert event["timestamp"]
+
+    @pytest.mark.asyncio
+    async def test_poll_once_api_failure(self):
+        """If the API returns non-200, poll_once should return None."""
+        mock_resp = AsyncMock()
+        mock_resp.status = 500
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.closed = False
+
+        connector = FearGreedConnector()
+        connector._session = mock_session
+
+        event = await connector.poll_once()
+        assert event is None
+
+    @pytest.mark.asyncio
+    async def test_poll_once_empty_data(self):
+        """If API returns empty data array, poll_once returns None."""
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"data": []})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.closed = False
+
+        connector = FearGreedConnector()
+        connector._session = mock_session
+
+        event = await connector.poll_once()
+        assert event is None
+
+    @pytest.mark.asyncio
+    async def test_poll_once_single_entry(self):
+        """With only 1 data point, previous_value should be None and trend stable."""
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={
+            "data": [
+                {"value": "50", "value_classification": "Neutral", "timestamp": "1711929600"},
+            ]
+        })
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.closed = False
+
+        connector = FearGreedConnector()
+        connector._session = mock_session
+
+        event = await connector.poll_once()
+        assert event is not None
+        assert event["value"] == 50
+        assert event["previous_value"] is None
+        assert event["trend"] == "stable"
+
+    @pytest.mark.asyncio
+    async def test_callback_invoked(self):
+        """Verify start() calls the callback with the event."""
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={
+            "data": [
+                {"value": "60", "value_classification": "Greed", "timestamp": "1711929600"},
+                {"value": "55", "value_classification": "Greed", "timestamp": "1711843200"},
+            ]
+        })
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session.get = MagicMock(return_value=mock_resp)
+        mock_session.closed = False
+
+        events = []
+
+        async def cb(event):
+            events.append(event)
+
+        connector = FearGreedConnector(callback=cb, poll_interval=0.01)
+        connector._session = mock_session
+
+        # Run poll_once directly instead of start() to avoid loop
+        event = await connector.poll_once()
+        if event and connector.callback:
+            await connector.callback(event)
+
+        assert len(events) == 1
+        assert events[0]["source"] == "fear_greed"
+        assert events[0]["value"] == 60
+
+    @pytest.mark.asyncio
+    async def test_close(self):
+        connector = FearGreedConnector()
+        # No session yet — close should be safe
+        await connector.close()
+
+    def test_stop(self):
+        connector = FearGreedConnector()
+        connector._running = True
+        connector.stop()
+        assert connector._running is False

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -145,6 +145,60 @@ class TestNormalizeEvent:
         assert "-2.3" in text
         assert "+" not in text
 
+    def test_fear_greed(self):
+        event = {
+            "source": "fear_greed",
+            "timestamp": "2026-04-01T10:00:00Z",
+            "value": 73,
+            "classification": "Greed",
+            "previous_value": 65,
+            "trend": "rising",
+        }
+        text = normalize_event(event)
+        assert "Fear & Greed" in text
+        assert "73" in text
+        assert "Greed" in text
+        assert "rising" in text
+        assert "65" in text
+
+    def test_fear_greed_no_previous(self):
+        event = {
+            "source": "fear_greed",
+            "value": 50,
+            "classification": "Neutral",
+            "trend": "stable",
+        }
+        text = normalize_event(event)
+        assert "50" in text
+        assert "previous" not in text
+
+    def test_predictit(self):
+        event = {
+            "source": "predictit",
+            "timestamp": "2026-04-01T10:00:00Z",
+            "market_id": "7456",
+            "market_name": "Who will win the 2026 Senate race?",
+            "contracts": [
+                {"name": "Alice", "price": 0.62},
+                {"name": "Bob", "price": 0.35},
+            ],
+        }
+        text = normalize_event(event)
+        assert "PredictIt" in text
+        assert "7456" in text
+        assert "Alice" in text
+        assert "0.62" in text
+
+    def test_predictit_empty_contracts(self):
+        event = {
+            "source": "predictit",
+            "market_id": "999",
+            "market_name": "Test Market",
+            "contracts": [],
+        }
+        text = normalize_event(event)
+        assert "Test Market" in text
+
     def test_unknown_source(self):
         event = {"source": "mystery", "data": "hello"}
         text = normalize_event(event)
@@ -198,6 +252,20 @@ class TestDedupKey:
     def test_fred_uses_series_and_timestamp(self):
         e1 = {"source": "fred", "series_id": "GDP", "timestamp": "2026-03-01"}
         e2 = {"source": "fred", "series_id": "GDP", "timestamp": "2026-03-02"}
+        assert _dedup_key(e1) != _dedup_key(e2)
+
+    def test_fear_greed_uses_value_and_timestamp(self):
+        e1 = {"source": "fear_greed", "value": 73, "timestamp": "2026-04-01T10:00:00Z"}
+        e2 = {"source": "fear_greed", "value": 73, "timestamp": "2026-04-01T11:00:00Z"}
+        assert _dedup_key(e1) != _dedup_key(e2)
+
+    def test_fear_greed_same_dedup(self):
+        e1 = {"source": "fear_greed", "value": 73, "timestamp": "2026-04-01T10:00:00Z"}
+        assert _dedup_key(e1) == _dedup_key(e1)
+
+    def test_predictit_uses_market_and_timestamp(self):
+        e1 = {"source": "predictit", "market_id": "100", "timestamp": "2026-04-01T10:00:00Z"}
+        e2 = {"source": "predictit", "market_id": "200", "timestamp": "2026-04-01T10:00:00Z"}
         assert _dedup_key(e1) != _dedup_key(e2)
 
 
@@ -322,6 +390,8 @@ class TestOrchestratorLifecycle:
             enable_whale=False,
             enable_reddit=False,
             enable_fred=False,
+            enable_fear_greed=False,
+            enable_predictit=False,
         )
         connectors = orch._build_connectors()
         assert connectors == []
@@ -337,6 +407,8 @@ class TestOrchestratorLifecycle:
             enable_whale=False,
             enable_reddit=False,
             enable_fred=False,
+            enable_fear_greed=False,
+            enable_predictit=False,
         )
         connectors = orch._build_connectors()
         assert connectors == []

--- a/tests/test_predictit.py
+++ b/tests/test_predictit.py
@@ -1,0 +1,297 @@
+"""Tests for the PredictIt connector — parsing, change detection, event format."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from aiohttp import ClientSession
+
+from ingestors.predictit import (
+    PredictItConnector,
+    _extract_contracts,
+    _market_fingerprint,
+    _build_market_event,
+)
+
+
+# ── Helper function tests ────────────────────────────────────────────────────
+
+
+class TestExtractContracts:
+    def test_basic_contracts(self):
+        market = {
+            "contracts": [
+                {"name": "Alice", "lastTradePrice": 0.62, "totalSharesTraded": 1234},
+                {"name": "Bob", "lastTradePrice": 0.35, "totalSharesTraded": 567},
+            ]
+        }
+        contracts = _extract_contracts(market)
+        assert len(contracts) == 2
+        assert contracts[0]["name"] == "Alice"
+        assert contracts[0]["price"] == 0.62
+        assert contracts[0]["volume"] == 1234
+        assert contracts[1]["name"] == "Bob"
+        assert contracts[1]["price"] == 0.35
+
+    def test_missing_fields(self):
+        market = {"contracts": [{"name": "Only Name"}]}
+        contracts = _extract_contracts(market)
+        assert len(contracts) == 1
+        assert contracts[0]["name"] == "Only Name"
+        assert contracts[0]["price"] is None
+        assert contracts[0]["volume"] == 0
+
+    def test_no_contracts_key(self):
+        contracts = _extract_contracts({})
+        assert contracts == []
+
+    def test_empty_contracts_list(self):
+        contracts = _extract_contracts({"contracts": []})
+        assert contracts == []
+
+
+class TestMarketFingerprint:
+    def test_deterministic(self):
+        contracts = [
+            {"name": "Alice", "price": 0.62},
+            {"name": "Bob", "price": 0.35},
+        ]
+        fp1 = _market_fingerprint(contracts)
+        fp2 = _market_fingerprint(contracts)
+        assert fp1 == fp2
+
+    def test_order_independent(self):
+        """Fingerprint should be the same regardless of contract order."""
+        c1 = [{"name": "Alice", "price": 0.62}, {"name": "Bob", "price": 0.35}]
+        c2 = [{"name": "Bob", "price": 0.35}, {"name": "Alice", "price": 0.62}]
+        assert _market_fingerprint(c1) == _market_fingerprint(c2)
+
+    def test_different_prices_different_fingerprint(self):
+        c1 = [{"name": "Alice", "price": 0.62}]
+        c2 = [{"name": "Alice", "price": 0.65}]
+        assert _market_fingerprint(c1) != _market_fingerprint(c2)
+
+    def test_empty_contracts(self):
+        assert _market_fingerprint([]) == ""
+
+
+class TestBuildMarketEvent:
+    def test_basic(self):
+        market = {
+            "id": 7456,
+            "name": "Who will win the 2026 Senate race in Pennsylvania?",
+            "contracts": [
+                {"name": "John Fetterman", "lastTradePrice": 0.62, "totalSharesTraded": 1234},
+            ],
+        }
+        event = _build_market_event(market, "2026-04-01T10:00:00+00:00")
+        assert event["source"] == "predictit"
+        assert event["market_id"] == "7456"
+        assert event["market_name"] == "Who will win the 2026 Senate race in Pennsylvania?"
+        assert event["timestamp"] == "2026-04-01T10:00:00+00:00"
+        assert len(event["contracts"]) == 1
+        assert event["contracts"][0]["name"] == "John Fetterman"
+        assert event["contracts"][0]["price"] == 0.62
+
+
+# ── Connector tests ──────────────────────────────────────────────────────────
+
+
+SAMPLE_API_RESPONSE = {
+    "markets": [
+        {
+            "id": 100,
+            "name": "Market A",
+            "contracts": [
+                {"name": "Yes", "lastTradePrice": 0.60, "totalSharesTraded": 500},
+                {"name": "No", "lastTradePrice": 0.40, "totalSharesTraded": 300},
+            ],
+        },
+        {
+            "id": 200,
+            "name": "Market B",
+            "contracts": [
+                {"name": "Candidate X", "lastTradePrice": 0.75, "totalSharesTraded": 1000},
+                {"name": "Candidate Y", "lastTradePrice": 0.25, "totalSharesTraded": 800},
+            ],
+        },
+    ]
+}
+
+
+def _make_mock_session(response_data, status=200):
+    """Create a mock aiohttp session that returns the given data."""
+    mock_resp = AsyncMock()
+    mock_resp.status = status
+    mock_resp.json = AsyncMock(return_value=response_data)
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = AsyncMock(spec=ClientSession)
+    mock_session.get = MagicMock(return_value=mock_resp)
+    mock_session.closed = False
+    return mock_session
+
+
+class TestPredictItConnector:
+    def test_defaults(self):
+        connector = PredictItConnector()
+        assert connector.poll_interval == 1800.0
+        assert connector.callback is None
+        assert connector._last_fingerprints == {}
+
+    @pytest.mark.asyncio
+    async def test_poll_once_first_call_returns_all(self):
+        """First poll should return all markets (no prior fingerprints)."""
+        connector = PredictItConnector()
+        connector._session = _make_mock_session(SAMPLE_API_RESPONSE)
+
+        events = await connector.poll_once()
+        assert len(events) == 2
+        assert events[0]["source"] == "predictit"
+        assert events[0]["market_id"] == "100"
+        assert events[1]["market_id"] == "200"
+
+    @pytest.mark.asyncio
+    async def test_poll_once_no_change_returns_empty(self):
+        """Second poll with same data should return empty (no changes)."""
+        connector = PredictItConnector()
+        connector._session = _make_mock_session(SAMPLE_API_RESPONSE)
+
+        # First poll — populates fingerprints.
+        events1 = await connector.poll_once()
+        assert len(events1) == 2
+
+        # Second poll — same data, no changes.
+        events2 = await connector.poll_once()
+        assert len(events2) == 0
+
+    @pytest.mark.asyncio
+    async def test_poll_once_detects_price_change(self):
+        """If one market's price changes, only that market is emitted."""
+        connector = PredictItConnector()
+        connector._session = _make_mock_session(SAMPLE_API_RESPONSE)
+
+        # First poll.
+        await connector.poll_once()
+
+        # Modify Market A's price.
+        changed_response = {
+            "markets": [
+                {
+                    "id": 100,
+                    "name": "Market A",
+                    "contracts": [
+                        {"name": "Yes", "lastTradePrice": 0.65, "totalSharesTraded": 550},
+                        {"name": "No", "lastTradePrice": 0.35, "totalSharesTraded": 320},
+                    ],
+                },
+                {
+                    "id": 200,
+                    "name": "Market B",
+                    "contracts": [
+                        {"name": "Candidate X", "lastTradePrice": 0.75, "totalSharesTraded": 1000},
+                        {"name": "Candidate Y", "lastTradePrice": 0.25, "totalSharesTraded": 800},
+                    ],
+                },
+            ]
+        }
+        connector._session = _make_mock_session(changed_response)
+
+        events = await connector.poll_once()
+        assert len(events) == 1
+        assert events[0]["market_id"] == "100"
+        # Volume change in Market B doesn't matter — price is the same.
+
+    @pytest.mark.asyncio
+    async def test_poll_once_api_failure(self):
+        """If API returns non-200, poll_once returns empty list."""
+        connector = PredictItConnector()
+        connector._session = _make_mock_session({}, status=500)
+
+        events = await connector.poll_once()
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_poll_once_empty_markets(self):
+        """If API returns no markets, poll_once returns empty list."""
+        connector = PredictItConnector()
+        connector._session = _make_mock_session({"markets": []})
+
+        events = await connector.poll_once()
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_callback_invoked_for_each_market(self):
+        """Verify callback is called once per changed market."""
+        events = []
+
+        async def cb(event):
+            events.append(event)
+
+        connector = PredictItConnector(callback=cb)
+        connector._session = _make_mock_session(SAMPLE_API_RESPONSE)
+
+        changed_events = await connector.poll_once()
+        for event in changed_events:
+            await connector.callback(event)
+
+        assert len(events) == 2
+
+    @pytest.mark.asyncio
+    async def test_market_without_id_skipped(self):
+        """Markets without an ID should be skipped."""
+        response = {
+            "markets": [
+                {
+                    "name": "No ID Market",
+                    "contracts": [{"name": "Yes", "lastTradePrice": 0.50}],
+                },
+                {
+                    "id": 999,
+                    "name": "Valid Market",
+                    "contracts": [{"name": "Yes", "lastTradePrice": 0.80}],
+                },
+            ]
+        }
+        connector = PredictItConnector()
+        connector._session = _make_mock_session(response)
+
+        events = await connector.poll_once()
+        assert len(events) == 1
+        assert events[0]["market_id"] == "999"
+
+    @pytest.mark.asyncio
+    async def test_close(self):
+        connector = PredictItConnector()
+        await connector.close()  # should be safe with no session
+
+    def test_stop(self):
+        connector = PredictItConnector()
+        connector._running = True
+        connector.stop()
+        assert connector._running is False
+
+    @pytest.mark.asyncio
+    async def test_volume_change_only_detected(self):
+        """Volume-only changes still change the fingerprint since volume
+        is not part of fingerprint — only price is. Verify this."""
+        connector = PredictItConnector()
+        connector._session = _make_mock_session(SAMPLE_API_RESPONSE)
+        await connector.poll_once()
+
+        # Only volume changed, price same.
+        same_price_response = {
+            "markets": [
+                {
+                    "id": 100,
+                    "name": "Market A",
+                    "contracts": [
+                        {"name": "Yes", "lastTradePrice": 0.60, "totalSharesTraded": 9999},
+                        {"name": "No", "lastTradePrice": 0.40, "totalSharesTraded": 9999},
+                    ],
+                },
+            ]
+        }
+        connector._session = _make_mock_session(same_price_response)
+        events = await connector.poll_once()
+        # Fingerprint is based on price only, so no change detected.
+        assert len(events) == 0


### PR DESCRIPTION
## Summary
Two new data source connectors for the ingestion pipeline:

- **Crypto Fear & Greed Index** (`ingestors/fear_greed.py`) — polls Alternative.me hourly, computes 7-day trend (rising/falling/stable), contrarian sentiment signal
- **PredictIt political markets** (`ingestors/predictit.py`) — polls every 30min, smart change detection via price fingerprinting (ignores volume-only changes)

Both wired into the orchestrator with normalizers, dedup keys, and enable/disable toggles.

Partial fix for #40

## Test plan
- [x] 40 new tests (20 per connector) — all passing
- [x] Orchestrator normalizer + dedup tests updated