### PR TITLE
Add Metaculus, Kalshi, and on-chain connectors (#40 Phase 2)

### DIFF
--- a/ingestors/kalshi.py
+++ b/ingestors/kalshi.py
@@ -1,0 +1,209 @@
+"""
+Kalshi Prediction Market Prices connector — polls the Kalshi API for
+open market data and emits events for markets with price changes.
+
+Endpoint: https://api.elections.kalshi.com/trade-api/v2/markets?limit=50&status=open
+Free, no API key required for market data read access.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+import aiohttp
+
+logger = logging.getLogger("prememora.ingestors.kalshi")
+
+API_URL = "https://api.elections.kalshi.com/trade-api/v2/markets"
+
+EventCallback = Callable[[Dict[str, Any]], Awaitable[None]]
+
+
+def _extract_yes_price(market: Dict[str, Any]) -> Optional[float]:
+    """Extract the yes price from a Kalshi market.
+
+    Kalshi uses cents (0-100), so we normalize to a 0-1 float.
+    The field may be 'yes_bid', 'last_price', or 'yes_price' depending
+    on API version. We try several paths.
+    """
+    # Try direct price fields (normalized 0-1)
+    for key in ("yes_price", "last_price"):
+        val = market.get(key)
+        if val is not None:
+            v = float(val)
+            # If > 1, assume cents (0-100) and normalize
+            return v / 100 if v > 1 else v
+
+    # Try cent-based fields
+    for key in ("yes_bid", "yes_ask"):
+        val = market.get(key)
+        if val is not None:
+            return float(val) / 100
+
+    return None
+
+
+def _market_fingerprint(ticker: str, yes_price: Optional[float]) -> str:
+    """Create a fingerprint for change detection.
+
+    Uses ticker + yes price rounded to 2 decimal places so that
+    tiny fluctuations still register as changes when meaningful.
+    """
+    if yes_price is None:
+        return f"{ticker}:none"
+    return f"{ticker}:{yes_price:.2f}"
+
+
+def _build_event(market: Dict[str, Any], yes_price: float) -> Dict[str, Any]:
+    """Build an event dict from a Kalshi market."""
+    ticker = market.get("ticker", "")
+    title = market.get("title", "") or market.get("event_title", "")
+    volume = market.get("volume", 0) or market.get("volume_24h", 0)
+    category = market.get("category", "") or market.get("series_ticker", "")
+
+    return {
+        "source": "kalshi",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "market_id": ticker,
+        "market_title": title,
+        "yes_price": yes_price,
+        "volume": volume,
+        "category": category,
+    }
+
+
+@dataclass
+class KalshiConnector:
+    """Polls Kalshi for open market data, emitting events on price change.
+
+    Parameters
+    ----------
+    callback : EventCallback | None
+        Async function called with each changed-market event dict.
+    poll_interval : float
+        Seconds between polls (default: 1800 = 30 minutes).
+    """
+
+    callback: Optional[EventCallback] = None
+    poll_interval: float = 1800.0
+    _running: bool = field(default=False, init=False)
+    _last_fingerprints: Dict[str, str] = field(default_factory=dict, init=False)
+    _session: Optional[aiohttp.ClientSession] = field(default=None, init=False, repr=False)
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=60),
+                headers={"Accept": "application/json"},
+            )
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    async def _fetch_markets(self) -> List[Dict[str, Any]]:
+        """Fetch open markets from Kalshi."""
+        session = await self._get_session()
+        params = {
+            "limit": 50,
+            "status": "open",
+        }
+        try:
+            async with session.get(API_URL, params=params) as resp:
+                if resp.status != 200:
+                    logger.warning("Kalshi API returned %d", resp.status)
+                    return []
+                data = await resp.json(content_type=None)
+                return data.get("markets", [])
+        except Exception as e:
+            logger.error("Failed to fetch Kalshi markets: %s", e)
+            return []
+
+    async def poll_once(self) -> List[Dict[str, Any]]:
+        """Single fetch: get open markets, return only those with price changes.
+
+        On first poll, all markets with valid prices are emitted.
+        """
+        raw_markets = await self._fetch_markets()
+        if not raw_markets:
+            return []
+
+        changed_events: List[Dict[str, Any]] = []
+
+        for market in raw_markets:
+            ticker = market.get("ticker", "")
+            if not ticker:
+                continue
+
+            yes_price = _extract_yes_price(market)
+            if yes_price is None:
+                continue
+
+            fingerprint = _market_fingerprint(ticker, yes_price)
+            old_fp = self._last_fingerprints.get(ticker)
+            if old_fp == fingerprint:
+                continue
+
+            self._last_fingerprints[ticker] = fingerprint
+            event = _build_event(market, yes_price)
+            changed_events.append(event)
+
+        return changed_events
+
+    async def start(self) -> None:
+        """Start the polling loop. Runs until stop() is called."""
+        self._running = True
+        logger.info("Kalshi connector starting, interval=%ss", self.poll_interval)
+
+        while self._running:
+            try:
+                events = await self.poll_once()
+                if events:
+                    logger.info("Kalshi: %d markets changed", len(events))
+                    if self.callback:
+                        for event in events:
+                            await self.callback(event)
+            except Exception:
+                logger.exception("Error during Kalshi poll cycle")
+
+            await asyncio.sleep(self.poll_interval)
+
+    def stop(self) -> None:
+        """Signal the polling loop to stop after the current cycle."""
+        self._running = False
+
+
+# ── Standalone demo ──────────────────────────────────────────────────────────
+
+
+async def _main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    )
+
+    async def print_event(event: Dict[str, Any]) -> None:
+        print(
+            f"  [{event['market_id']}] {event['market_title']}"
+            f"\n    YES={event['yes_price']:.2f}, vol={event['volume']}, "
+            f"cat={event['category']}"
+        )
+
+    connector = KalshiConnector(callback=print_event, poll_interval=60)
+    print("Polling Kalshi markets — Ctrl-C to stop\n")
+
+    try:
+        await connector.start()
+    except KeyboardInterrupt:
+        connector.stop()
+    finally:
+        await connector.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/ingestors/metaculus.py
+++ b/ingestors/metaculus.py
@@ -1,0 +1,206 @@
+"""
+Metaculus Expert Forecasts connector — polls the Metaculus API for
+open forecast questions and emits events when community probabilities change.
+
+Endpoint: https://www.metaculus.com/api2/questions/?status=open&type=forecast&limit=50&order_by=-activity
+Free, no API key required for read access.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+import aiohttp
+
+logger = logging.getLogger("prememora.ingestors.metaculus")
+
+BASE_URL = "https://www.metaculus.com/api2/questions/"
+
+EventCallback = Callable[[Dict[str, Any]], Awaitable[None]]
+
+
+def _extract_probability(question: Dict[str, Any]) -> Optional[float]:
+    """Extract the community probability from a Metaculus question.
+
+    Path: aggregations.recency_weighted.latest.centers[0]
+
+    Returns the probability as a float in [0, 1], or None if unavailable.
+    """
+    try:
+        aggregations = question.get("aggregations", {})
+        recency = aggregations.get("recency_weighted", {})
+        latest = recency.get("latest", {})
+        centers = latest.get("centers", [])
+        if centers:
+            return float(centers[0])
+    except (TypeError, ValueError, IndexError):
+        pass
+    return None
+
+
+def _question_fingerprint(question_id: int, probability: Optional[float]) -> str:
+    """Create a fingerprint for change detection.
+
+    Uses question ID + probability rounded to 4 decimal places so that
+    tiny floating-point jitter doesn't trigger spurious events.
+    """
+    if probability is None:
+        return f"{question_id}:none"
+    return f"{question_id}:{probability:.4f}"
+
+
+def _build_event(question: Dict[str, Any], probability: float) -> Dict[str, Any]:
+    """Build an event dict from a Metaculus question."""
+    question_id = question.get("id", 0)
+    title = question.get("title", "")
+    num_forecasters = question.get("number_of_forecasters", 0)
+    url = f"https://www.metaculus.com/questions/{question_id}/"
+
+    return {
+        "source": "metaculus",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "question_id": question_id,
+        "question_title": title,
+        "community_probability": probability,
+        "num_forecasters": num_forecasters,
+        "url": url,
+    }
+
+
+@dataclass
+class MetaculusConnector:
+    """Polls Metaculus for open forecast questions, emitting events on probability change.
+
+    Parameters
+    ----------
+    callback : EventCallback | None
+        Async function called with each changed-question event dict.
+    poll_interval : float
+        Seconds between polls (default: 21600 = 6 hours).
+    """
+
+    callback: Optional[EventCallback] = None
+    poll_interval: float = 21600.0
+    _running: bool = field(default=False, init=False)
+    _last_fingerprints: Dict[int, str] = field(default_factory=dict, init=False)
+    _session: Optional[aiohttp.ClientSession] = field(default=None, init=False, repr=False)
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=60),
+                headers={"Accept": "application/json"},
+            )
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    async def _fetch_questions(self) -> List[Dict[str, Any]]:
+        """Fetch open forecast questions from Metaculus."""
+        session = await self._get_session()
+        params = {
+            "status": "open",
+            "type": "forecast",
+            "limit": 50,
+            "order_by": "-activity",
+        }
+        try:
+            async with session.get(BASE_URL, params=params) as resp:
+                if resp.status != 200:
+                    logger.warning("Metaculus API returned %d", resp.status)
+                    return []
+                data = await resp.json(content_type=None)
+                return data.get("results", [])
+        except Exception as e:
+            logger.error("Failed to fetch Metaculus questions: %s", e)
+            return []
+
+    async def poll_once(self) -> List[Dict[str, Any]]:
+        """Single fetch: get open questions, return only those with probability changes.
+
+        On first poll, all questions with valid probabilities are emitted.
+        """
+        raw_questions = await self._fetch_questions()
+        if not raw_questions:
+            return []
+
+        changed_events: List[Dict[str, Any]] = []
+
+        for question in raw_questions:
+            question_id = question.get("id")
+            if not question_id:
+                continue
+
+            probability = _extract_probability(question)
+            if probability is None:
+                continue
+
+            fingerprint = _question_fingerprint(question_id, probability)
+            old_fp = self._last_fingerprints.get(question_id)
+            if old_fp == fingerprint:
+                continue
+
+            self._last_fingerprints[question_id] = fingerprint
+            event = _build_event(question, probability)
+            changed_events.append(event)
+
+        return changed_events
+
+    async def start(self) -> None:
+        """Start the polling loop. Runs until stop() is called."""
+        self._running = True
+        logger.info("Metaculus connector starting, interval=%ss", self.poll_interval)
+
+        while self._running:
+            try:
+                events = await self.poll_once()
+                if events:
+                    logger.info("Metaculus: %d questions changed", len(events))
+                    if self.callback:
+                        for event in events:
+                            await self.callback(event)
+            except Exception:
+                logger.exception("Error during Metaculus poll cycle")
+
+            await asyncio.sleep(self.poll_interval)
+
+    def stop(self) -> None:
+        """Signal the polling loop to stop after the current cycle."""
+        self._running = False
+
+
+# ── Standalone demo ──────────────────────────────────────────────────────────
+
+
+async def _main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    )
+
+    async def print_event(event: Dict[str, Any]) -> None:
+        print(
+            f"  [{event['question_id']}] {event['question_title']}"
+            f"\n    P={event['community_probability']:.2%}, "
+            f"forecasters={event['num_forecasters']}"
+        )
+
+    connector = MetaculusConnector(callback=print_event, poll_interval=60)
+    print("Polling Metaculus forecasts — Ctrl-C to stop\n")
+
+    try:
+        await connector.start()
+    except KeyboardInterrupt:
+        connector.stop()
+    finally:
+        await connector.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/ingestors/onchain.py
+++ b/ingestors/onchain.py
@@ -1,0 +1,265 @@
+"""
+Bitcoin On-Chain Metrics connector — polls the BGeometrics API for
+key on-chain indicators (MVRV Z-Score, SOPR, NUPL) and emits events
+with current values, previous values, and market-phase interpretations.
+
+Endpoints:
+  - https://charts.bgeometrics.com/apiservice?chart=mvrv_zscore&format=json
+  - https://charts.bgeometrics.com/apiservice?chart=sopr&format=json
+  - https://charts.bgeometrics.com/apiservice?chart=nupl&format=json
+
+Free, no API key required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+
+import aiohttp
+
+logger = logging.getLogger("prememora.ingestors.onchain")
+
+BASE_URL = "https://charts.bgeometrics.com/apiservice"
+
+EventCallback = Callable[[Dict[str, Any]], Awaitable[None]]
+
+# Metrics to fetch, with their chart parameter names.
+METRICS = ["mvrv_zscore", "sopr", "nupl"]
+
+
+def _interpret_mvrv(value: float) -> str:
+    """Interpret MVRV Z-Score.
+
+    <0 = undervalued (historically good buy zone)
+    0-3 = fair value range
+    >3 = overvalued / potential market top signal
+    """
+    if value < 0:
+        return "undervalued"
+    elif value <= 3:
+        return "fair"
+    else:
+        return "overvalued"
+
+
+def _interpret_sopr(value: float) -> str:
+    """Interpret Spent Output Profit Ratio.
+
+    <1 = selling at loss (capitulation / accumulation)
+    =1 = breakeven
+    >1 = selling at profit (distribution)
+    """
+    if value < 1:
+        return "selling_at_loss"
+    elif value == 1.0:
+        return "breakeven"
+    else:
+        return "selling_at_profit"
+
+
+def _interpret_nupl(value: float) -> str:
+    """Interpret Net Unrealized Profit/Loss.
+
+    <0 = capitulation (holders underwater)
+    0-0.25 = hope / fear
+    0.25-0.5 = optimism / anxiety
+    0.5-0.75 = belief / denial
+    >0.75 = euphoria / greed
+    """
+    if value < 0:
+        return "capitulation"
+    elif value < 0.25:
+        return "hope_fear"
+    elif value < 0.5:
+        return "optimism"
+    elif value < 0.75:
+        return "belief"
+    else:
+        return "euphoria"
+
+
+_INTERPRETERS = {
+    "mvrv_zscore": _interpret_mvrv,
+    "sopr": _interpret_sopr,
+    "nupl": _interpret_nupl,
+}
+
+
+def _parse_metric_data(data: Any) -> Optional[Tuple[float, float]]:
+    """Parse BGeometrics JSON response into (latest_value, previous_value).
+
+    The API returns a list of [date, value] pairs sorted by date ascending.
+    We take the last two entries for current and previous values.
+
+    Returns None if the data is not parseable.
+    """
+    if not isinstance(data, list) or len(data) < 1:
+        return None
+
+    try:
+        # Try list-of-lists format: [[date, value], ...]
+        if isinstance(data[0], (list, tuple)) and len(data[0]) >= 2:
+            latest = float(data[-1][1])
+            previous = float(data[-2][1]) if len(data) >= 2 else latest
+            return latest, previous
+
+        # Try list-of-dicts format: [{"date": ..., "value": ...}, ...]
+        if isinstance(data[0], dict):
+            val_key = None
+            for key in ("value", "v", "y"):
+                if key in data[0]:
+                    val_key = key
+                    break
+            if val_key:
+                latest = float(data[-1][val_key])
+                previous = float(data[-2][val_key]) if len(data) >= 2 else latest
+                return latest, previous
+
+        # Try plain list of numbers
+        if isinstance(data[0], (int, float)):
+            latest = float(data[-1])
+            previous = float(data[-2]) if len(data) >= 2 else latest
+            return latest, previous
+
+    except (TypeError, ValueError, IndexError, KeyError):
+        pass
+
+    return None
+
+
+@dataclass
+class OnChainConnector:
+    """Polls BGeometrics for Bitcoin on-chain metrics, emitting events per metric.
+
+    Parameters
+    ----------
+    callback : EventCallback | None
+        Async function called with each metric event dict.
+    poll_interval : float
+        Seconds between polls (default: 21600 = 6 hours).
+    """
+
+    callback: Optional[EventCallback] = None
+    poll_interval: float = 21600.0
+    _running: bool = field(default=False, init=False)
+    _last_values: Dict[str, float] = field(default_factory=dict, init=False)
+    _session: Optional[aiohttp.ClientSession] = field(default=None, init=False, repr=False)
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=60),
+                headers={"Accept": "application/json"},
+            )
+        return self._session
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    async def _fetch_metric(self, chart: str) -> Any:
+        """Fetch a single metric from BGeometrics."""
+        session = await self._get_session()
+        params = {"chart": chart, "format": "json"}
+        try:
+            async with session.get(BASE_URL, params=params) as resp:
+                if resp.status != 200:
+                    logger.warning("BGeometrics API returned %d for %s", resp.status, chart)
+                    return None
+                return await resp.json(content_type=None)
+        except Exception as e:
+            logger.error("Failed to fetch on-chain metric %s: %s", chart, e)
+            return None
+
+    async def poll_once(self) -> List[Dict[str, Any]]:
+        """Fetch all metrics and return events for each.
+
+        Each metric produces one event with the latest value, previous
+        value, and a human-readable interpretation.
+        """
+        events: List[Dict[str, Any]] = []
+
+        for metric in METRICS:
+            raw_data = await self._fetch_metric(metric)
+            if raw_data is None:
+                continue
+
+            parsed = _parse_metric_data(raw_data)
+            if parsed is None:
+                logger.warning("Could not parse data for %s", metric)
+                continue
+
+            value, previous_value = parsed
+            interpreter = _INTERPRETERS.get(metric)
+            interpretation = interpreter(value) if interpreter else "unknown"
+
+            event: Dict[str, Any] = {
+                "source": "onchain",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "metric": metric,
+                "value": value,
+                "previous_value": previous_value,
+                "interpretation": interpretation,
+            }
+
+            self._last_values[metric] = value
+            events.append(event)
+
+        return events
+
+    async def start(self) -> None:
+        """Start the polling loop. Runs until stop() is called."""
+        self._running = True
+        logger.info("On-chain connector starting, interval=%ss", self.poll_interval)
+
+        while self._running:
+            try:
+                events = await self.poll_once()
+                if events:
+                    logger.info("On-chain: %d metrics fetched", len(events))
+                    if self.callback:
+                        for event in events:
+                            await self.callback(event)
+            except Exception:
+                logger.exception("Error during on-chain poll cycle")
+
+            await asyncio.sleep(self.poll_interval)
+
+    def stop(self) -> None:
+        """Signal the polling loop to stop after the current cycle."""
+        self._running = False
+
+
+# ── Standalone demo ──────────────────────────────────────────────────────────
+
+
+async def _main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    )
+
+    async def print_event(event: Dict[str, Any]) -> None:
+        print(
+            f"  {event['metric']}: {event['value']:.4f} "
+            f"(prev={event['previous_value']:.4f}) "
+            f"— {event['interpretation']}"
+        )
+
+    connector = OnChainConnector(callback=print_event, poll_interval=60)
+    print("Polling Bitcoin on-chain metrics — Ctrl-C to stop\n")
+
+    try:
+        await connector.start()
+    except KeyboardInterrupt:
+        connector.stop()
+    finally:
+        await connector.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/ingestors/orchestrator.py
+++ b/ingestors/orchestrator.py
@@ -168,6 +168,47 @@ def _normalize_predictit(event: dict[str, Any]) -> str:
     return "\n".join(parts)
 
 
+def _normalize_metaculus(event: dict[str, Any]) -> str:
+    title = event.get("question_title", "Unknown question")
+    qid = event.get("question_id", "?")
+    prob = event.get("community_probability")
+    forecasters = event.get("num_forecasters", 0)
+    url = event.get("url", "")
+
+    prob_str = f"{prob:.1%}" if prob is not None else "N/A"
+    text = f"Metaculus forecast [{qid}]: {title} — community P={prob_str}, forecasters={forecasters}"
+    if url:
+        text += f" ({url})"
+    return text
+
+
+def _normalize_kalshi(event: dict[str, Any]) -> str:
+    title = event.get("market_title", "Unknown market")
+    market_id = event.get("market_id", "?")
+    yes_price = event.get("yes_price")
+    volume = event.get("volume", 0)
+    category = event.get("category", "")
+
+    price_str = f"{yes_price:.2f}" if yes_price is not None else "N/A"
+    text = f"Kalshi market [{market_id}]: {title} — YES={price_str}, volume={volume}"
+    if category:
+        text += f", category={category}"
+    return text
+
+
+def _normalize_onchain(event: dict[str, Any]) -> str:
+    metric = event.get("metric", "unknown")
+    value = event.get("value")
+    previous = event.get("previous_value")
+    interpretation = event.get("interpretation", "unknown")
+
+    val_str = f"{value:.4f}" if value is not None else "N/A"
+    text = f"Bitcoin on-chain {metric}: {val_str} ({interpretation})"
+    if previous is not None:
+        text += f", previous={previous:.4f}"
+    return text
+
+
 _NORMALIZERS: dict[str, Any] = {
     "polymarket_ws": _normalize_polymarket,
     "crypto_news": _normalize_crypto_news,
@@ -177,6 +218,9 @@ _NORMALIZERS: dict[str, Any] = {
     "fred": _normalize_fred,
     "fear_greed": _normalize_fear_greed,
     "predictit": _normalize_predictit,
+    "metaculus": _normalize_metaculus,
+    "kalshi": _normalize_kalshi,
+    "onchain": _normalize_onchain,
 }
 
 
@@ -218,6 +262,12 @@ def _dedup_key(event: dict[str, Any]) -> str:
         raw = f"{event.get('value')}:{event.get('timestamp')}"
     elif source == "predictit":
         raw = f"{event.get('market_id')}:{event.get('timestamp')}"
+    elif source == "metaculus":
+        raw = f"{event.get('question_id')}:{event.get('community_probability')}"
+    elif source == "kalshi":
+        raw = f"{event.get('market_id')}:{event.get('yes_price')}"
+    elif source == "onchain":
+        raw = f"{event.get('metric')}:{event.get('value')}"
     else:
         raw = str(event)
 
@@ -276,6 +326,9 @@ class IngestionOrchestrator:
     enable_fred: bool = True
     enable_fear_greed: bool = True
     enable_predictit: bool = True
+    enable_metaculus: bool = True
+    enable_kalshi: bool = True
+    enable_onchain: bool = True
 
     # Internals
     _dedup: _LRUDedup = field(default_factory=_LRUDedup, init=False)
@@ -384,6 +437,24 @@ class IngestionOrchestrator:
 
             c = PredictItConnector(callback=self._handle_event)
             connectors.append(("predictit", c))
+
+        if self.enable_metaculus:
+            from ingestors.metaculus import MetaculusConnector
+
+            c = MetaculusConnector(callback=self._handle_event)
+            connectors.append(("metaculus", c))
+
+        if self.enable_kalshi:
+            from ingestors.kalshi import KalshiConnector
+
+            c = KalshiConnector(callback=self._handle_event)
+            connectors.append(("kalshi", c))
+
+        if self.enable_onchain:
+            from ingestors.onchain import OnChainConnector
+
+            c = OnChainConnector(callback=self._handle_event)
+            connectors.append(("onchain", c))
 
         return connectors
 

--- a/tests/test_kalshi.py
+++ b/tests/test_kalshi.py
@@ -1,0 +1,362 @@
+"""Tests for the Kalshi connector — price extraction, change detection, event format."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from aiohttp import ClientSession
+
+from ingestors.kalshi import (
+    KalshiConnector,
+    _extract_yes_price,
+    _market_fingerprint,
+    _build_event,
+)
+
+
+# ── Helper function tests ────────────────────────────────────────────────────
+
+
+class TestExtractYesPrice:
+    def test_yes_price_normalized(self):
+        """yes_price as a 0-1 float."""
+        market = {"yes_price": 0.72}
+        assert _extract_yes_price(market) == 0.72
+
+    def test_yes_price_cents(self):
+        """yes_price in cents (>1) should be normalized to 0-1."""
+        market = {"yes_price": 72}
+        assert _extract_yes_price(market) == 0.72
+
+    def test_last_price(self):
+        market = {"last_price": 0.65}
+        assert _extract_yes_price(market) == 0.65
+
+    def test_last_price_cents(self):
+        market = {"last_price": 65}
+        assert _extract_yes_price(market) == 0.65
+
+    def test_yes_bid_cents(self):
+        """yes_bid is always in cents."""
+        market = {"yes_bid": 55}
+        assert _extract_yes_price(market) == 0.55
+
+    def test_yes_ask_cents(self):
+        market = {"yes_ask": 80}
+        assert _extract_yes_price(market) == 0.80
+
+    def test_no_price_fields(self):
+        assert _extract_yes_price({}) is None
+
+    def test_priority_yes_price_over_bid(self):
+        """yes_price should be preferred over yes_bid."""
+        market = {"yes_price": 0.72, "yes_bid": 70}
+        assert _extract_yes_price(market) == 0.72
+
+    def test_zero_price(self):
+        """Zero is a valid price (market at 0%)."""
+        market = {"yes_price": 0}
+        # 0 is falsy but not None, however 0 > 1 is False so stays 0
+        assert _extract_yes_price(market) == 0.0
+
+
+class TestMarketFingerprint:
+    def test_deterministic(self):
+        fp1 = _market_fingerprint("KXBTC-26APR04", 0.72)
+        fp2 = _market_fingerprint("KXBTC-26APR04", 0.72)
+        assert fp1 == fp2
+
+    def test_different_price_different_fingerprint(self):
+        fp1 = _market_fingerprint("KXBTC-26APR04", 0.72)
+        fp2 = _market_fingerprint("KXBTC-26APR04", 0.75)
+        assert fp1 != fp2
+
+    def test_different_ticker_different_fingerprint(self):
+        fp1 = _market_fingerprint("KXBTC-A", 0.72)
+        fp2 = _market_fingerprint("KXBTC-B", 0.72)
+        assert fp1 != fp2
+
+    def test_none_price(self):
+        fp = _market_fingerprint("KXBTC-A", None)
+        assert "none" in fp
+
+    def test_rounding_same_fingerprint(self):
+        """Prices rounded to 2 decimals — tiny differences should match."""
+        fp1 = _market_fingerprint("KXBTC-A", 0.721)
+        fp2 = _market_fingerprint("KXBTC-A", 0.724)
+        assert fp1 == fp2
+
+    def test_rounding_different_fingerprint(self):
+        """Large enough difference should differ."""
+        fp1 = _market_fingerprint("KXBTC-A", 0.72)
+        fp2 = _market_fingerprint("KXBTC-A", 0.73)
+        assert fp1 != fp2
+
+
+class TestBuildEvent:
+    def test_basic(self):
+        market = {
+            "ticker": "KXBTC-26APR04-T64400",
+            "title": "Bitcoin above $64,400 on April 4?",
+            "volume": 50000,
+            "category": "Crypto",
+        }
+        event = _build_event(market, 0.72)
+        assert event["source"] == "kalshi"
+        assert event["market_id"] == "KXBTC-26APR04-T64400"
+        assert event["market_title"] == "Bitcoin above $64,400 on April 4?"
+        assert event["yes_price"] == 0.72
+        assert event["volume"] == 50000
+        assert event["category"] == "Crypto"
+        assert event["timestamp"]
+
+    def test_event_title_fallback(self):
+        """If title is missing, try event_title."""
+        market = {
+            "ticker": "TEST",
+            "event_title": "Fallback Title",
+        }
+        event = _build_event(market, 0.50)
+        assert event["market_title"] == "Fallback Title"
+
+    def test_volume_fallback(self):
+        """If volume is missing, try volume_24h."""
+        market = {
+            "ticker": "TEST",
+            "volume_24h": 12345,
+        }
+        event = _build_event(market, 0.50)
+        assert event["volume"] == 12345
+
+    def test_category_fallback(self):
+        """If category is missing, try series_ticker."""
+        market = {
+            "ticker": "TEST",
+            "series_ticker": "ECON",
+        }
+        event = _build_event(market, 0.50)
+        assert event["category"] == "ECON"
+
+    def test_missing_fields(self):
+        event = _build_event({}, 0.5)
+        assert event["market_id"] == ""
+        assert event["market_title"] == ""
+        assert event["volume"] == 0
+        assert event["category"] == ""
+
+
+# ── Connector tests ──────────────────────────────────────────────────────────
+
+
+SAMPLE_API_RESPONSE = {
+    "markets": [
+        {
+            "ticker": "KXBTC-26APR04-T64400",
+            "title": "Bitcoin above $64,400 on April 4?",
+            "yes_price": 0.72,
+            "volume": 50000,
+            "category": "Crypto",
+        },
+        {
+            "ticker": "KXFED-26MAY01-T525",
+            "title": "Fed rate above 5.25% on May 1?",
+            "yes_price": 0.45,
+            "volume": 30000,
+            "category": "Economics",
+        },
+    ]
+}
+
+
+def _make_mock_session(response_data, status=200):
+    """Create a mock aiohttp session that returns the given data."""
+    mock_resp = AsyncMock()
+    mock_resp.status = status
+    mock_resp.json = AsyncMock(return_value=response_data)
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = AsyncMock(spec=ClientSession)
+    mock_session.get = MagicMock(return_value=mock_resp)
+    mock_session.closed = False
+    return mock_session
+
+
+class TestKalshiConnector:
+    def test_defaults(self):
+        connector = KalshiConnector()
+        assert connector.poll_interval == 1800.0
+        assert connector.callback is None
+        assert connector._last_fingerprints == {}
+
+    @pytest.mark.asyncio
+    async def test_poll_once_first_call_returns_all(self):
+        """First poll should return all markets with valid prices."""
+        connector = KalshiConnector()
+        connector._session = _make_mock_session(SAMPLE_API_RESPONSE)
+
+        events = await connector.poll_once()
+        assert len(events) == 2
+        assert events[0]["source"] == "kalshi"
+        assert events[0]["market_id"] == "KXBTC-26APR04-T64400"
+        assert events[0]["yes_price"] == 0.72
+        assert events[1]["market_id"] == "KXFED-26MAY01-T525"
+        assert events[1]["yes_price"] == 0.45
+
+    @pytest.mark.asyncio
+    async def test_poll_once_no_change_returns_empty(self):
+        """Second poll with same data should return empty (no changes)."""
+        connector = KalshiConnector()
+        connector._session = _make_mock_session(SAMPLE_API_RESPONSE)
+
+        events1 = await connector.poll_once()
+        assert len(events1) == 2
+
+        events2 = await connector.poll_once()
+        assert len(events2) == 0
+
+    @pytest.mark.asyncio
+    async def test_poll_once_detects_price_change(self):
+        """If one market's price changes, only that market is emitted."""
+        connector = KalshiConnector()
+        connector._session = _make_mock_session(SAMPLE_API_RESPONSE)
+
+        await connector.poll_once()
+
+        changed_response = {
+            "markets": [
+                {
+                    "ticker": "KXBTC-26APR04-T64400",
+                    "title": "Bitcoin above $64,400 on April 4?",
+                    "yes_price": 0.78,  # changed from 0.72
+                    "volume": 55000,
+                    "category": "Crypto",
+                },
+                {
+                    "ticker": "KXFED-26MAY01-T525",
+                    "title": "Fed rate above 5.25% on May 1?",
+                    "yes_price": 0.45,  # unchanged
+                    "volume": 30000,
+                    "category": "Economics",
+                },
+            ]
+        }
+        connector._session = _make_mock_session(changed_response)
+
+        events = await connector.poll_once()
+        assert len(events) == 1
+        assert events[0]["market_id"] == "KXBTC-26APR04-T64400"
+        assert events[0]["yes_price"] == 0.78
+
+    @pytest.mark.asyncio
+    async def test_poll_once_api_failure(self):
+        """If API returns non-200, poll_once returns empty list."""
+        connector = KalshiConnector()
+        connector._session = _make_mock_session({}, status=500)
+
+        events = await connector.poll_once()
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_poll_once_empty_markets(self):
+        """If API returns no markets, poll_once returns empty list."""
+        connector = KalshiConnector()
+        connector._session = _make_mock_session({"markets": []})
+
+        events = await connector.poll_once()
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_market_without_ticker_skipped(self):
+        """Markets without a ticker should be skipped."""
+        response = {
+            "markets": [
+                {
+                    "title": "No Ticker Market",
+                    "yes_price": 0.50,
+                },
+                {
+                    "ticker": "VALID-MKT",
+                    "title": "Valid Market",
+                    "yes_price": 0.80,
+                },
+            ]
+        }
+        connector = KalshiConnector()
+        connector._session = _make_mock_session(response)
+
+        events = await connector.poll_once()
+        assert len(events) == 1
+        assert events[0]["market_id"] == "VALID-MKT"
+
+    @pytest.mark.asyncio
+    async def test_market_without_price_skipped(self):
+        """Markets without any price field should be skipped."""
+        response = {
+            "markets": [
+                {
+                    "ticker": "NO-PRICE",
+                    "title": "No price data",
+                },
+                {
+                    "ticker": "HAS-PRICE",
+                    "title": "Has price",
+                    "yes_price": 0.60,
+                },
+            ]
+        }
+        connector = KalshiConnector()
+        connector._session = _make_mock_session(response)
+
+        events = await connector.poll_once()
+        assert len(events) == 1
+        assert events[0]["market_id"] == "HAS-PRICE"
+
+    @pytest.mark.asyncio
+    async def test_callback_invoked_for_each_market(self):
+        """Verify callback is called once per changed market."""
+        events = []
+
+        async def cb(event):
+            events.append(event)
+
+        connector = KalshiConnector(callback=cb)
+        connector._session = _make_mock_session(SAMPLE_API_RESPONSE)
+
+        changed_events = await connector.poll_once()
+        for event in changed_events:
+            await connector.callback(event)
+
+        assert len(events) == 2
+
+    @pytest.mark.asyncio
+    async def test_volume_change_only_not_detected(self):
+        """Volume-only changes should not trigger a new event (price-based fingerprint)."""
+        connector = KalshiConnector()
+        connector._session = _make_mock_session(SAMPLE_API_RESPONSE)
+        await connector.poll_once()
+
+        # Only volume changed, price same.
+        same_price_response = {
+            "markets": [
+                {
+                    "ticker": "KXBTC-26APR04-T64400",
+                    "title": "Bitcoin above $64,400 on April 4?",
+                    "yes_price": 0.72,  # same price
+                    "volume": 99999,  # different volume
+                    "category": "Crypto",
+                },
+            ]
+        }
+        connector._session = _make_mock_session(same_price_response)
+        events = await connector.poll_once()
+        assert len(events) == 0
+
+    @pytest.mark.asyncio
+    async def test_close(self):
+        connector = KalshiConnector()
+        await connector.close()  # should be safe with no session
+
+    def test_stop(self):
+        connector = KalshiConnector()
+        connector._running = True
+        connector.stop()
+        assert connector._running is False

--- a/tests/test_metaculus.py
+++ b/tests/test_metaculus.py
@@ -1,0 +1,365 @@
+"""Tests for the Metaculus connector — probability extraction, change detection, event format."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from aiohttp import ClientSession
+
+from ingestors.metaculus import (
+    MetaculusConnector,
+    _extract_probability,
+    _question_fingerprint,
+    _build_event,
+)
+
+
+# ── Helper function tests ────────────────────────────────────────────────────
+
+
+class TestExtractProbability:
+    def test_standard_path(self):
+        question = {
+            "aggregations": {
+                "recency_weighted": {
+                    "latest": {
+                        "centers": [0.35],
+                    }
+                }
+            }
+        }
+        assert _extract_probability(question) == 0.35
+
+    def test_multiple_centers_takes_first(self):
+        question = {
+            "aggregations": {
+                "recency_weighted": {
+                    "latest": {
+                        "centers": [0.42, 0.58],
+                    }
+                }
+            }
+        }
+        assert _extract_probability(question) == 0.42
+
+    def test_empty_centers(self):
+        question = {
+            "aggregations": {
+                "recency_weighted": {
+                    "latest": {
+                        "centers": [],
+                    }
+                }
+            }
+        }
+        assert _extract_probability(question) is None
+
+    def test_missing_aggregations(self):
+        assert _extract_probability({}) is None
+
+    def test_missing_recency_weighted(self):
+        question = {"aggregations": {}}
+        assert _extract_probability(question) is None
+
+    def test_missing_latest(self):
+        question = {"aggregations": {"recency_weighted": {}}}
+        assert _extract_probability(question) is None
+
+    def test_missing_centers_key(self):
+        question = {"aggregations": {"recency_weighted": {"latest": {}}}}
+        assert _extract_probability(question) is None
+
+    def test_none_in_centers(self):
+        """If centers contains None, float() should fail gracefully."""
+        question = {
+            "aggregations": {
+                "recency_weighted": {
+                    "latest": {
+                        "centers": [None],
+                    }
+                }
+            }
+        }
+        assert _extract_probability(question) is None
+
+    def test_string_value_in_centers(self):
+        """String values should be converted to float."""
+        question = {
+            "aggregations": {
+                "recency_weighted": {
+                    "latest": {
+                        "centers": ["0.75"],
+                    }
+                }
+            }
+        }
+        assert _extract_probability(question) == 0.75
+
+
+class TestQuestionFingerprint:
+    def test_deterministic(self):
+        fp1 = _question_fingerprint(123, 0.35)
+        fp2 = _question_fingerprint(123, 0.35)
+        assert fp1 == fp2
+
+    def test_different_probability_different_fingerprint(self):
+        fp1 = _question_fingerprint(123, 0.35)
+        fp2 = _question_fingerprint(123, 0.40)
+        assert fp1 != fp2
+
+    def test_different_question_different_fingerprint(self):
+        fp1 = _question_fingerprint(123, 0.35)
+        fp2 = _question_fingerprint(456, 0.35)
+        assert fp1 != fp2
+
+    def test_none_probability(self):
+        fp = _question_fingerprint(123, None)
+        assert "none" in fp
+
+    def test_tiny_jitter_same_fingerprint(self):
+        """Probability rounded to 4 decimals, so tiny jitter should match."""
+        fp1 = _question_fingerprint(123, 0.350001)
+        fp2 = _question_fingerprint(123, 0.350002)
+        assert fp1 == fp2
+
+
+class TestBuildEvent:
+    def test_basic(self):
+        question = {
+            "id": 12345,
+            "title": "Will AI pass the Turing test by 2030?",
+            "number_of_forecasters": 450,
+        }
+        event = _build_event(question, 0.35)
+        assert event["source"] == "metaculus"
+        assert event["question_id"] == 12345
+        assert event["question_title"] == "Will AI pass the Turing test by 2030?"
+        assert event["community_probability"] == 0.35
+        assert event["num_forecasters"] == 450
+        assert "12345" in event["url"]
+        assert event["timestamp"]
+
+    def test_missing_fields(self):
+        event = _build_event({}, 0.5)
+        assert event["question_id"] == 0
+        assert event["question_title"] == ""
+        assert event["num_forecasters"] == 0
+
+
+# ── Connector tests ──────────────────────────────────────────────────────────
+
+
+SAMPLE_API_RESPONSE = {
+    "results": [
+        {
+            "id": 100,
+            "title": "Will Bitcoin reach $100k by 2026?",
+            "number_of_forecasters": 500,
+            "aggregations": {
+                "recency_weighted": {
+                    "latest": {"centers": [0.65]}
+                }
+            },
+        },
+        {
+            "id": 200,
+            "title": "Will there be a US recession in 2026?",
+            "number_of_forecasters": 300,
+            "aggregations": {
+                "recency_weighted": {
+                    "latest": {"centers": [0.30]}
+                }
+            },
+        },
+    ]
+}
+
+
+def _make_mock_session(response_data, status=200):
+    """Create a mock aiohttp session that returns the given data."""
+    mock_resp = AsyncMock()
+    mock_resp.status = status
+    mock_resp.json = AsyncMock(return_value=response_data)
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = AsyncMock(spec=ClientSession)
+    mock_session.get = MagicMock(return_value=mock_resp)
+    mock_session.closed = False
+    return mock_session
+
+
+class TestMetaculusConnector:
+    def test_defaults(self):
+        connector = MetaculusConnector()
+        assert connector.poll_interval == 21600.0
+        assert connector.callback is None
+        assert connector._last_fingerprints == {}
+
+    @pytest.mark.asyncio
+    async def test_poll_once_first_call_returns_all(self):
+        """First poll should return all questions with valid probabilities."""
+        connector = MetaculusConnector()
+        connector._session = _make_mock_session(SAMPLE_API_RESPONSE)
+
+        events = await connector.poll_once()
+        assert len(events) == 2
+        assert events[0]["source"] == "metaculus"
+        assert events[0]["question_id"] == 100
+        assert events[0]["community_probability"] == 0.65
+        assert events[1]["question_id"] == 200
+        assert events[1]["community_probability"] == 0.30
+
+    @pytest.mark.asyncio
+    async def test_poll_once_no_change_returns_empty(self):
+        """Second poll with same data should return empty (no changes)."""
+        connector = MetaculusConnector()
+        connector._session = _make_mock_session(SAMPLE_API_RESPONSE)
+
+        events1 = await connector.poll_once()
+        assert len(events1) == 2
+
+        events2 = await connector.poll_once()
+        assert len(events2) == 0
+
+    @pytest.mark.asyncio
+    async def test_poll_once_detects_probability_change(self):
+        """If one question's probability changes, only that question is emitted."""
+        connector = MetaculusConnector()
+        connector._session = _make_mock_session(SAMPLE_API_RESPONSE)
+
+        await connector.poll_once()
+
+        changed_response = {
+            "results": [
+                {
+                    "id": 100,
+                    "title": "Will Bitcoin reach $100k by 2026?",
+                    "number_of_forecasters": 510,
+                    "aggregations": {
+                        "recency_weighted": {
+                            "latest": {"centers": [0.70]}  # changed from 0.65
+                        }
+                    },
+                },
+                {
+                    "id": 200,
+                    "title": "Will there be a US recession in 2026?",
+                    "number_of_forecasters": 300,
+                    "aggregations": {
+                        "recency_weighted": {
+                            "latest": {"centers": [0.30]}  # unchanged
+                        }
+                    },
+                },
+            ]
+        }
+        connector._session = _make_mock_session(changed_response)
+
+        events = await connector.poll_once()
+        assert len(events) == 1
+        assert events[0]["question_id"] == 100
+        assert events[0]["community_probability"] == 0.70
+
+    @pytest.mark.asyncio
+    async def test_poll_once_api_failure(self):
+        """If API returns non-200, poll_once returns empty list."""
+        connector = MetaculusConnector()
+        connector._session = _make_mock_session({}, status=500)
+
+        events = await connector.poll_once()
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_poll_once_empty_results(self):
+        """If API returns no results, poll_once returns empty list."""
+        connector = MetaculusConnector()
+        connector._session = _make_mock_session({"results": []})
+
+        events = await connector.poll_once()
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_question_without_id_skipped(self):
+        """Questions without an ID should be skipped."""
+        response = {
+            "results": [
+                {
+                    "title": "No ID Question",
+                    "aggregations": {
+                        "recency_weighted": {
+                            "latest": {"centers": [0.50]}
+                        }
+                    },
+                },
+                {
+                    "id": 999,
+                    "title": "Valid Question",
+                    "aggregations": {
+                        "recency_weighted": {
+                            "latest": {"centers": [0.80]}
+                        }
+                    },
+                },
+            ]
+        }
+        connector = MetaculusConnector()
+        connector._session = _make_mock_session(response)
+
+        events = await connector.poll_once()
+        assert len(events) == 1
+        assert events[0]["question_id"] == 999
+
+    @pytest.mark.asyncio
+    async def test_question_without_probability_skipped(self):
+        """Questions without valid probability data should be skipped."""
+        response = {
+            "results": [
+                {
+                    "id": 111,
+                    "title": "No probability data",
+                    "aggregations": {},
+                },
+                {
+                    "id": 222,
+                    "title": "Valid",
+                    "aggregations": {
+                        "recency_weighted": {
+                            "latest": {"centers": [0.55]}
+                        }
+                    },
+                },
+            ]
+        }
+        connector = MetaculusConnector()
+        connector._session = _make_mock_session(response)
+
+        events = await connector.poll_once()
+        assert len(events) == 1
+        assert events[0]["question_id"] == 222
+
+    @pytest.mark.asyncio
+    async def test_callback_invoked_for_each_question(self):
+        """Verify callback is called once per changed question."""
+        events = []
+
+        async def cb(event):
+            events.append(event)
+
+        connector = MetaculusConnector(callback=cb)
+        connector._session = _make_mock_session(SAMPLE_API_RESPONSE)
+
+        changed_events = await connector.poll_once()
+        for event in changed_events:
+            await connector.callback(event)
+
+        assert len(events) == 2
+
+    @pytest.mark.asyncio
+    async def test_close(self):
+        connector = MetaculusConnector()
+        await connector.close()  # should be safe with no session
+
+    def test_stop(self):
+        connector = MetaculusConnector()
+        connector._running = True
+        connector.stop()
+        assert connector._running is False

--- a/tests/test_onchain.py
+++ b/tests/test_onchain.py
@@ -1,0 +1,378 @@
+"""Tests for the On-Chain Metrics connector — parsing, interpretation thresholds, event format."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from aiohttp import ClientSession
+
+from ingestors.onchain import (
+    OnChainConnector,
+    _interpret_mvrv,
+    _interpret_sopr,
+    _interpret_nupl,
+    _parse_metric_data,
+)
+
+
+# ── Interpretation function tests ────────────────────────────────────────────
+
+
+class TestInterpretMVRV:
+    def test_undervalued(self):
+        assert _interpret_mvrv(-0.5) == "undervalued"
+        assert _interpret_mvrv(-2.0) == "undervalued"
+
+    def test_undervalued_boundary(self):
+        """Exactly 0 should be fair, not undervalued."""
+        assert _interpret_mvrv(0) == "fair"
+
+    def test_fair(self):
+        assert _interpret_mvrv(1.5) == "fair"
+        assert _interpret_mvrv(0.1) == "fair"
+        assert _interpret_mvrv(3.0) == "fair"
+
+    def test_overvalued(self):
+        assert _interpret_mvrv(3.1) == "overvalued"
+        assert _interpret_mvrv(7.0) == "overvalued"
+
+
+class TestInterpretSOPR:
+    def test_selling_at_loss(self):
+        assert _interpret_sopr(0.95) == "selling_at_loss"
+        assert _interpret_sopr(0.5) == "selling_at_loss"
+
+    def test_breakeven(self):
+        assert _interpret_sopr(1.0) == "breakeven"
+
+    def test_selling_at_profit(self):
+        assert _interpret_sopr(1.05) == "selling_at_profit"
+        assert _interpret_sopr(1.5) == "selling_at_profit"
+
+
+class TestInterpretNUPL:
+    def test_capitulation(self):
+        assert _interpret_nupl(-0.1) == "capitulation"
+        assert _interpret_nupl(-0.5) == "capitulation"
+
+    def test_hope_fear(self):
+        assert _interpret_nupl(0.0) == "hope_fear"
+        assert _interpret_nupl(0.24) == "hope_fear"
+
+    def test_optimism(self):
+        assert _interpret_nupl(0.25) == "optimism"
+        assert _interpret_nupl(0.49) == "optimism"
+
+    def test_belief(self):
+        assert _interpret_nupl(0.5) == "belief"
+        assert _interpret_nupl(0.74) == "belief"
+
+    def test_euphoria(self):
+        assert _interpret_nupl(0.75) == "euphoria"
+        assert _interpret_nupl(0.9) == "euphoria"
+
+
+# ── Data parsing tests ───────────────────────────────────────────────────────
+
+
+class TestParseMetricData:
+    def test_list_of_lists(self):
+        """Standard format: [[date, value], ...]"""
+        data = [
+            ["2026-04-01", 1.8],
+            ["2026-04-02", 1.9],
+            ["2026-04-03", 2.1],
+        ]
+        result = _parse_metric_data(data)
+        assert result is not None
+        value, previous = result
+        assert value == 2.1
+        assert previous == 1.9
+
+    def test_list_of_dicts_value_key(self):
+        """Dict format with 'value' key."""
+        data = [
+            {"date": "2026-04-01", "value": 0.95},
+            {"date": "2026-04-02", "value": 1.02},
+        ]
+        result = _parse_metric_data(data)
+        assert result is not None
+        value, previous = result
+        assert value == 1.02
+        assert previous == 0.95
+
+    def test_list_of_dicts_v_key(self):
+        """Dict format with 'v' key."""
+        data = [
+            {"t": "2026-04-01", "v": 0.3},
+            {"t": "2026-04-02", "v": 0.4},
+        ]
+        result = _parse_metric_data(data)
+        assert result is not None
+        value, previous = result
+        assert value == 0.4
+        assert previous == 0.3
+
+    def test_list_of_dicts_y_key(self):
+        """Dict format with 'y' key."""
+        data = [
+            {"x": "2026-04-01", "y": 1.5},
+            {"x": "2026-04-02", "y": 1.6},
+        ]
+        result = _parse_metric_data(data)
+        assert result is not None
+        value, previous = result
+        assert value == 1.6
+        assert previous == 1.5
+
+    def test_plain_list_of_numbers(self):
+        """Plain list of numeric values."""
+        data = [1.5, 1.6, 1.8, 2.0]
+        result = _parse_metric_data(data)
+        assert result is not None
+        value, previous = result
+        assert value == 2.0
+        assert previous == 1.8
+
+    def test_single_entry(self):
+        """Single entry: previous should equal latest."""
+        data = [["2026-04-01", 2.5]]
+        result = _parse_metric_data(data)
+        assert result is not None
+        value, previous = result
+        assert value == 2.5
+        assert previous == 2.5
+
+    def test_empty_list(self):
+        result = _parse_metric_data([])
+        assert result is None
+
+    def test_none_input(self):
+        result = _parse_metric_data(None)
+        assert result is None
+
+    def test_non_list_input(self):
+        result = _parse_metric_data("not a list")
+        assert result is None
+
+    def test_string_values_converted(self):
+        """String numeric values should be converted to float."""
+        data = [["2026-04-01", "1.8"], ["2026-04-02", "2.1"]]
+        result = _parse_metric_data(data)
+        assert result is not None
+        value, previous = result
+        assert value == 2.1
+        assert previous == 1.8
+
+    def test_dict_without_known_value_key(self):
+        """Dicts without known value keys should return None."""
+        data = [{"date": "2026-04-01", "unknown_key": 1.5}]
+        result = _parse_metric_data(data)
+        assert result is None
+
+
+# ── Connector tests ──────────────────────────────────────────────────────────
+
+
+# Sample responses for each metric (list-of-lists format).
+SAMPLE_MVRV_DATA = [
+    ["2026-04-01", 1.8],
+    ["2026-04-02", 1.9],
+    ["2026-04-03", 2.1],
+]
+
+SAMPLE_SOPR_DATA = [
+    ["2026-04-01", 0.98],
+    ["2026-04-02", 1.01],
+    ["2026-04-03", 1.03],
+]
+
+SAMPLE_NUPL_DATA = [
+    ["2026-04-01", 0.45],
+    ["2026-04-02", 0.48],
+    ["2026-04-03", 0.52],
+]
+
+
+def _make_mock_session_multi(metric_data_map, status=200):
+    """Create a mock session that returns different data based on the chart param.
+
+    metric_data_map: dict mapping chart name → response data.
+    """
+    mock_session = AsyncMock(spec=ClientSession)
+    mock_session.closed = False
+
+    def make_response(data, st):
+        mock_resp = AsyncMock()
+        mock_resp.status = st
+        mock_resp.json = AsyncMock(return_value=data)
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        return mock_resp
+
+    call_count = [0]
+    responses = []
+
+    # Build responses in the order METRICS are fetched: mvrv_zscore, sopr, nupl
+    from ingestors.onchain import METRICS
+    for metric in METRICS:
+        data = metric_data_map.get(metric)
+        if data is not None:
+            responses.append(make_response(data, status))
+        else:
+            responses.append(make_response(None, 404))
+
+    def side_effect(*args, **kwargs):
+        idx = call_count[0]
+        call_count[0] += 1
+        if idx < len(responses):
+            return responses[idx]
+        return make_response(None, 500)
+
+    mock_session.get = MagicMock(side_effect=side_effect)
+    return mock_session
+
+
+class TestOnChainConnector:
+    def test_defaults(self):
+        connector = OnChainConnector()
+        assert connector.poll_interval == 21600.0
+        assert connector.callback is None
+        assert connector._last_values == {}
+
+    @pytest.mark.asyncio
+    async def test_poll_once_returns_all_metrics(self):
+        """poll_once should return one event per metric."""
+        connector = OnChainConnector()
+        connector._session = _make_mock_session_multi({
+            "mvrv_zscore": SAMPLE_MVRV_DATA,
+            "sopr": SAMPLE_SOPR_DATA,
+            "nupl": SAMPLE_NUPL_DATA,
+        })
+
+        events = await connector.poll_once()
+        assert len(events) == 3
+
+        metrics = [e["metric"] for e in events]
+        assert "mvrv_zscore" in metrics
+        assert "sopr" in metrics
+        assert "nupl" in metrics
+
+    @pytest.mark.asyncio
+    async def test_mvrv_event_structure(self):
+        """Verify MVRV event has correct fields."""
+        connector = OnChainConnector()
+        connector._session = _make_mock_session_multi({
+            "mvrv_zscore": SAMPLE_MVRV_DATA,
+            "sopr": SAMPLE_SOPR_DATA,
+            "nupl": SAMPLE_NUPL_DATA,
+        })
+
+        events = await connector.poll_once()
+        mvrv_event = [e for e in events if e["metric"] == "mvrv_zscore"][0]
+
+        assert mvrv_event["source"] == "onchain"
+        assert mvrv_event["value"] == 2.1
+        assert mvrv_event["previous_value"] == 1.9
+        assert mvrv_event["interpretation"] == "fair"
+        assert mvrv_event["timestamp"]
+
+    @pytest.mark.asyncio
+    async def test_sopr_event_interpretation(self):
+        """SOPR > 1 should be selling_at_profit."""
+        connector = OnChainConnector()
+        connector._session = _make_mock_session_multi({
+            "mvrv_zscore": SAMPLE_MVRV_DATA,
+            "sopr": SAMPLE_SOPR_DATA,
+            "nupl": SAMPLE_NUPL_DATA,
+        })
+
+        events = await connector.poll_once()
+        sopr_event = [e for e in events if e["metric"] == "sopr"][0]
+        assert sopr_event["interpretation"] == "selling_at_profit"
+
+    @pytest.mark.asyncio
+    async def test_nupl_event_interpretation(self):
+        """NUPL 0.52 should be belief."""
+        connector = OnChainConnector()
+        connector._session = _make_mock_session_multi({
+            "mvrv_zscore": SAMPLE_MVRV_DATA,
+            "sopr": SAMPLE_SOPR_DATA,
+            "nupl": SAMPLE_NUPL_DATA,
+        })
+
+        events = await connector.poll_once()
+        nupl_event = [e for e in events if e["metric"] == "nupl"][0]
+        assert nupl_event["interpretation"] == "belief"
+
+    @pytest.mark.asyncio
+    async def test_partial_api_failure(self):
+        """If one metric API fails, others should still return."""
+        connector = OnChainConnector()
+        # Only provide mvrv and nupl, sopr will 404
+        connector._session = _make_mock_session_multi({
+            "mvrv_zscore": SAMPLE_MVRV_DATA,
+            "nupl": SAMPLE_NUPL_DATA,
+        })
+
+        events = await connector.poll_once()
+        metrics = [e["metric"] for e in events]
+        assert "mvrv_zscore" in metrics
+        assert "nupl" in metrics
+        # sopr may or may not be present depending on mock behavior
+        # The key test: at least mvrv and nupl were fetched
+        assert len(events) >= 2
+
+    @pytest.mark.asyncio
+    async def test_all_api_failure(self):
+        """If all APIs fail, poll_once returns empty."""
+        connector = OnChainConnector()
+        connector._session = _make_mock_session_multi({}, status=500)
+
+        events = await connector.poll_once()
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_callback_invoked(self):
+        """Verify callback is called for each metric event."""
+        events = []
+
+        async def cb(event):
+            events.append(event)
+
+        connector = OnChainConnector(callback=cb)
+        connector._session = _make_mock_session_multi({
+            "mvrv_zscore": SAMPLE_MVRV_DATA,
+            "sopr": SAMPLE_SOPR_DATA,
+            "nupl": SAMPLE_NUPL_DATA,
+        })
+
+        fetched = await connector.poll_once()
+        for event in fetched:
+            await connector.callback(event)
+
+        assert len(events) == 3
+
+    @pytest.mark.asyncio
+    async def test_close(self):
+        connector = OnChainConnector()
+        await connector.close()  # should be safe with no session
+
+    def test_stop(self):
+        connector = OnChainConnector()
+        connector._running = True
+        connector.stop()
+        assert connector._running is False
+
+    @pytest.mark.asyncio
+    async def test_last_values_updated(self):
+        """poll_once should update _last_values dict."""
+        connector = OnChainConnector()
+        connector._session = _make_mock_session_multi({
+            "mvrv_zscore": SAMPLE_MVRV_DATA,
+            "sopr": SAMPLE_SOPR_DATA,
+            "nupl": SAMPLE_NUPL_DATA,
+        })
+
+        await connector.poll_once()
+        assert connector._last_values.get("mvrv_zscore") == 2.1
+        assert connector._last_values.get("sopr") == 1.03
+        assert connector._last_values.get("nupl") == 0.52

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -377,9 +377,21 @@ class TestOrchestratorHandleEvent:
 
 class TestOrchestratorLifecycle:
     def test_requires_graph_id(self):
-        orch = IngestionOrchestrator()
+        orch = IngestionOrchestrator(
+            enable_polymarket=False,
+            enable_crypto_news=False,
+            enable_rss=False,
+            enable_whale=False,
+            enable_reddit=False,
+            enable_fred=False,
+            enable_fear_greed=False,
+            enable_predictit=False,
+            enable_metaculus=False,
+            enable_kalshi=False,
+            enable_onchain=False,
+        )
         with pytest.raises(ValueError, match="graph_id is required"):
-            asyncio.get_event_loop().run_until_complete(orch.start())
+            asyncio.run(orch.start())
 
     def test_build_connectors_all_disabled(self):
         orch = IngestionOrchestrator(
@@ -392,6 +404,9 @@ class TestOrchestratorLifecycle:
             enable_fred=False,
             enable_fear_greed=False,
             enable_predictit=False,
+            enable_metaculus=False,
+            enable_kalshi=False,
+            enable_onchain=False,
         )
         connectors = orch._build_connectors()
         assert connectors == []
@@ -409,6 +424,9 @@ class TestOrchestratorLifecycle:
             enable_fred=False,
             enable_fear_greed=False,
             enable_predictit=False,
+            enable_metaculus=False,
+            enable_kalshi=False,
+            enable_onchain=False,
         )
         connectors = orch._build_connectors()
         assert connectors == []


### PR DESCRIPTION
## Summary
Three new data source connectors:

- **Metaculus** (`ingestors/metaculus.py`) — expert forecast probabilities (best-calibrated public forecasting community). Change detection on probability shifts. Polls every 6h.
- **Kalshi** (`ingestors/kalshi.py`) — regulated US prediction market prices. Cross-market divergence vs Polymarket = trading signal. Fingerprint-based change detection. Polls every 30min.
- **BGeometrics on-chain** (`ingestors/onchain.py`) — Bitcoin MVRV Z-Score, SOPR, NUPL with interpretation thresholds (undervalued/overvalued signals). Polls every 6h.

All wired into orchestrator with normalizers, dedup keys, and toggles.

Partial fix for #40

## Test plan
- [x] 93 new tests (27 metaculus + 32 kalshi + 34 onchain) — all passing
- [x] Orchestrator tests updated for new connector toggles